### PR TITLE
Fix Shogun kmeans benchmark run

### DIFF
--- a/methods/shogun/kmeans.py
+++ b/methods/shogun/kmeans.py
@@ -63,7 +63,7 @@ class KMEANS(object):
         data = np.genfromtxt(self.dataset[0], delimiter=',')
         centroids = np.genfromtxt(self.dataset[1], delimiter=',')
       else:
-        data = np.genfromtxt(self.dataset, delimiter=',')
+        data = np.genfromtxt(self.dataset[0], delimiter=',')
 
       # Gather parameters.
       clusters = re.search("-c (\d+)", options)


### PR DESCRIPTION
Stack trace happening without this patch:
```
[INFO ] Dataset: 1000000-10-randu
Process Process-1:
Traceback (most recent call last):
  File "/usr/lib/python3.5/multiprocessing/process.py", line 249, in _bootstrap
    self.run()
  File "/usr/lib/python3.5/multiprocessing/process.py", line 93, in run
    self._target(*self._args, **self._kwargs)
  File "methods/shogun/kmeans.py", line 66, in RunKMeansShogun
    data = np.genfromtxt(self.dataset, delimiter=',')
  File "/home/gut/venv/lib/python3.5/site-packages/numpy/lib/npyio.py", line 1541, in genfromtxt
    first_values = split_line(first_line)
  File "/home/gut/venv/lib/python3.5/site-packages/numpy/lib/_iotools.py", line 219, in _delimited_splitter
    line = line.split(self.comments)[0]
TypeError: Can't convert 'bytes' object to str implicitly
```
benchmark affected: 1000000-10-randu