### PR TITLE
sweep support and options as dictionaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ ifndef PYTHON_BIN
     PYTHON_BIN := $(shell which python)
   endif
 endif
-
 ifdef PYTHON_BIN
 # Get the python version.
 ifeq ($(shell expr `$(PYTHON_BIN) -c 'import sys; print(sys.version[:3])'` \>= 3.3)	, 1)

--- a/config.yaml
+++ b/config.yaml
@@ -41,7 +41,8 @@ methods:
                        ['datasets/abalone7_train.csv', 'datasets/abalone7_test.csv', 'datasets/abalone7_labels.csv'],
                        ['datasets/satellite_train.csv', 'datasets/satellite_test.csv', 'datasets/satellite_labels.csv'],
                        ['datasets/ecoli_train.csv', 'datasets/ecoli_test.csv', 'datasets/ecoli_labels.csv'] ]
-              options: '-n 10000'
+              options:
+                max_iterations: 10000
 
     DecisionStump:
         run: ['metric']
@@ -65,21 +66,30 @@ methods:
                       'datasets/TomsHardware.csv', 'datasets/pendigits.csv',
                       'datasets/isolet.csv', 'datasets/mnist_all.csv',
                       'datasets/tinyImages100k.csv', 'datasets/yearpredictionmsd.csv']
-              options: '-r 6 -s 42 -u multdist'
+              options:
+                rank: 6
+                seed: 42
+                update_rules: multdist
 
             - files: ['datasets/ionosphere.csv', 'datasets/piano_magnitude_spectogram.csv',
                       'datasets/optdigits.csv', 'datasets/waveform.csv',
                       'datasets/TomsHardware.csv', 'datasets/pendigits.csv',
                       'datasets/isolet.csv', 'datasets/mnist_all.csv',
                       'datasets/tinyImages100k.csv', 'datasets/yearpredictionmsd.csv']
-              options: '-r 6 -s 42 -u multdiv'
+              options:
+                rank: 6
+                seed: 42
+                update_rules: multdiv
 
             - files: ['datasets/ionosphere.csv', 'datasets/piano_magnitude_spectogram.csv',
                       'datasets/optdigits.csv', 'datasets/waveform.csv',
                       'datasets/TomsHardware.csv', 'datasets/pendigits.csv',
                       'datasets/isolet.csv', 'datasets/mnist_all.csv',
                       'datasets/tinyImages100k.csv', 'datasets/yearpredictionmsd.csv']
-              options: '-r 6 -s 42 -u als'
+              options:
+                rank: 6
+                seed: 42
+                update_rules: als
     NBC:
         run: ['metric']
         script: methods/mlpack/nbc.py
@@ -92,7 +102,8 @@ methods:
             - files: [ ['datasets/iris_train.csv', 'datasets/iris_test.csv'],
                        ['datasets/transfusion_train.csv', 'datasets/transfusion_test.csv'],
                        ['datasets/madelon_train.csv', 'datasets/madelon_test.csv'] ]
-              options: '-I'
+              options:
+                incremental: True
     KPCA:
         run: ['metric']
         script: methods/mlpack/kernel_pca.py
@@ -104,7 +115,8 @@ methods:
                       'datasets/arcene_X.csv', 'datasets/madelon_X.csv',
                       'datasets/pendigits.csv', 'datasets/isolet.csv',
                       'datasets/covtype.csv']
-              options: '-k linear'
+              options:
+                kernel: linear
 
             - files: ['datasets/circle_data.csv', 'datasets/stock.csv',
                       'datasets/abalone.csv', 'datasets/bank8FM.csv',
@@ -112,7 +124,8 @@ methods:
                       'datasets/arcene_X.csv', 'datasets/madelon_X.csv',
                       'datasets/pendigits.csv', 'datasets/isolet.csv',
                       'datasets/covtype.csv']
-              options: '-k gaussian'
+              options:
+                kernel: gaussian
 
             - files: ['datasets/circle_data.csv', 'datasets/stock.csv',
                       'datasets/abalone.csv', 'datasets/bank8FM.csv',
@@ -120,7 +133,8 @@ methods:
                       'datasets/arcene_X.csv', 'datasets/madelon_X.csv',
                       'datasets/pendigits.csv', 'datasets/isolet.csv',
                       'datasets/covtype.csv']
-              options: '-k polynomial'
+              options:
+                kernel: polynomial
 
             - files: ['datasets/circle_data.csv', 'datasets/stock.csv',
                       'datasets/abalone.csv', 'datasets/bank8FM.csv',
@@ -128,7 +142,8 @@ methods:
                       'datasets/arcene_X.csv', 'datasets/madelon_X.csv',
                       'datasets/pendigits.csv', 'datasets/isolet.csv',
                       'datasets/covtype.csv']
-              options: '-k hyptan'
+              options:
+                kernel: hyptan
 
             - files: ['datasets/circle_data.csv', 'datasets/stock.csv',
                       'datasets/abalone.csv', 'datasets/bank8FM.csv',
@@ -136,7 +151,8 @@ methods:
                       'datasets/arcene_X.csv', 'datasets/madelon_X.csv',
                       'datasets/pendigits.csv', 'datasets/isolet.csv',
                       'datasets/covtype.csv']
-              options: '-k laplacian'
+              options:
+                kernel: laplacian
 
             - files: ['datasets/circle_data.csv', 'datasets/stock.csv',
                       'datasets/abalone.csv', 'datasets/bank8FM.csv',
@@ -144,7 +160,8 @@ methods:
                       'datasets/arcene_X.csv', 'datasets/madelon_X.csv',
                       'datasets/pendigits.csv', 'datasets/isolet.csv',
                       'datasets/covtype.csv']
-              options: '-k cosine'
+              options:
+                kernel: cosine
 
             - files: ['datasets/circle_data.csv', 'datasets/stock.csv',
                       'datasets/abalone.csv', 'datasets/bank8FM.csv',
@@ -152,7 +169,10 @@ methods:
                       'datasets/arcene_X.csv', 'datasets/madelon_X.csv',
                       'datasets/pendigits.csv', 'datasets/isolet.csv',
                       'datasets/covtype.csv']
-              options: '-k gaussian --nystroem_method -s kmeans'
+              options:
+                kernel: gaussian
+                nystroem: true
+                sampling_scheme: kmeans
 
             - files: ['datasets/circle_data.csv', 'datasets/stock.csv',
                       'datasets/abalone.csv', 'datasets/bank8FM.csv',
@@ -160,7 +180,10 @@ methods:
                       'datasets/arcene_X.csv', 'datasets/madelon_X.csv',
                       'datasets/pendigits.csv', 'datasets/isolet.csv',
                       'datasets/covtype.csv']
-              options: '-k polynomial --nystroem_method -s kmeans'
+              options:
+                kernel: polynomial
+                nystroem: true
+                sampling_scheme: kmeans
 
             - files: ['datasets/circle_data.csv', 'datasets/stock.csv',
                       'datasets/abalone.csv', 'datasets/bank8FM.csv',
@@ -168,7 +191,10 @@ methods:
                       'datasets/arcene_X.csv', 'datasets/madelon_X.csv',
                       'datasets/pendigits.csv', 'datasets/isolet.csv',
                       'datasets/covtype.csv']
-              options: '-k cosine --nystroem_method -s kmeans'
+              options:
+                kernel: cosine
+                nystroem: true
+                sampling_scheme: kmeans
 
             - files: ['datasets/circle_data.csv', 'datasets/stock.csv',
                       'datasets/abalone.csv', 'datasets/bank8FM.csv',
@@ -176,7 +202,10 @@ methods:
                       'datasets/arcene_X.csv', 'datasets/madelon_X.csv',
                       'datasets/pendigits.csv', 'datasets/isolet.csv',
                       'datasets/covtype.csv']
-              options: '-k gaussian --nystroem_method -s random'
+              options:
+                kernel: gaussian
+                nystroem: true
+                sampling_scheme: random
 
             - files: ['datasets/circle_data.csv', 'datasets/stock.csv',
                       'datasets/abalone.csv', 'datasets/bank8FM.csv',
@@ -184,7 +213,10 @@ methods:
                       'datasets/arcene_X.csv', 'datasets/madelon_X.csv',
                       'datasets/pendigits.csv', 'datasets/isolet.csv',
                       'datasets/covtype.csv']
-              options: '-k polynomial --nystroem_method -s random'
+              options:
+                kernel: polynomial
+                nystroem: true
+                sampling_scheme: random
 
             - files: ['datasets/circle_data.csv', 'datasets/stock.csv',
                       'datasets/abalone.csv', 'datasets/bank8FM.csv',
@@ -192,7 +224,11 @@ methods:
                       'datasets/arcene_X.csv', 'datasets/madelon_X.csv',
                       'datasets/pendigits.csv', 'datasets/isolet.csv',
                       'datasets/covtype.csv']
-              options: '-k cosine --nystroem_method -s random'
+              options:
+                kernel: cosine
+                nystroem: true
+                sampling_scheme: random
+
     LARS:
           run: ['metric']
           script: methods/mlpack/lars.py
@@ -202,13 +238,17 @@ methods:
                          ['datasets/cosExp_X.csv', 'datasets/cosExp_y.csv'],
                          ['datasets/arcene_X.csv', 'datasets/arcene_y.csv'],
                          ['datasets/madelon_X.csv', 'datasets/madelon_y.csv'] ]
-                options: '-l 0.01'
+                options:
+                  lambda1: 0.01
 
               - files: [ ['datasets/diabetes_X.csv', 'datasets/diabetes_y.csv'],
                          ['datasets/cosExp_X.csv', 'datasets/cosExp_y.csv'],
                          ['datasets/arcene_X.csv', 'datasets/arcene_y.csv'],
                          ['datasets/madelon_X.csv', 'datasets/madelon_y.csv'] ]
-                options: '--lambda1 0.01 --lambda2 0.005 --use_cholesky'
+                options:
+                  lambda1: 0.01
+                  lambda2: 0.005
+                  use_cholesky: True
 
     LSH:
         run: ['metric']
@@ -220,7 +260,9 @@ methods:
                    'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                    'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                    'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-           options: '-k 3 -s 42'
+           options:
+              k: 3
+              seed: 42
 
     KMEANS:
         run: ['metric']
@@ -228,31 +270,40 @@ methods:
         format: [csv, txt, arff]
         datasets:
             - files: [ ['datasets/waveform.csv', 'datasets/waveform_centroids.csv'] ]
-              options: '-c 2'
+              options:
+                clusters: 2
 
             - files: [ ['datasets/wine.csv', 'datasets/wine_centroids.csv'],
                        ['datasets/iris.csv', 'datasets/iris_centroids.csv'] ]
-              options: '-c 3'
+              options:
+                clusters: 3
 
             - files: [ ['datasets/cloud.csv', 'datasets/cloud_centroids.csv'] ]
-              options: '-c 5'
+              options:
+                clusters: 5
 
             - files: [ ['datasets/USCensus1990.csv', 'datasets/USCensus1990_centroids.csv'] ]
-              options: '-c 6'
+              options:
+                clusters: 6
 
             - files: [ ['datasets/covtype.csv', 'datasets/covtype_centroids.csv'],
                        ['datasets/wine_qual.csv', 'datasets/wine_qual_centroids.csv'] ]
-              options: '-c 7'
+              options:
+                clusters: 7
 
             - files: [ ['datasets/isolet.csv', 'datasets/isolet_centroids.csv'] ]
-              options: '-c 26'
+              options:
+                clusters: 26
 
             - files: [ ['datasets/mnist_all.csv', 'datasets/mnist_all_centroids.csv'],
                        ['datasets/corel-histogram.csv', 'datasets/corel-histogram_centroids.csv'] ]
-              options: '-c 10'
+              options:
+                clusters: 10
 
             - files: [ ['datasets/1000000-10-randu.csv'] ]
-              options: '-c 75'
+              options:
+                clusters: 75
+
     ALLKNN:
         run: ['metric']
         script: methods/mlpack/allknn.py
@@ -263,84 +314,118 @@ methods:
                       'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                       'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                       'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-              options: '-k 3'
+              options:
+                k: 3
 
             - files: ['datasets/wine.csv', 'datasets/cloud.csv',
                       'datasets/wine_qual.csv', 'datasets/isolet.csv',
                       'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                       'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                       'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-              options: '-k 4'
+              options:
+                k: 4
 
             - files: ['datasets/wine.csv', 'datasets/cloud.csv',
                       'datasets/wine_qual.csv', 'datasets/isolet.csv',
                       'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                       'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                       'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-              options: '-k 3 -s 42 -e 0.0'
+              options:
+                k: 3
+                seed: 42
+                epsilon: 0.0
 
             - files: ['datasets/wine.csv', 'datasets/cloud.csv',
                       'datasets/wine_qual.csv', 'datasets/isolet.csv',
                       'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                       'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                       'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-              options: '-k 3 -s 42 -e 0.05'
+              options:
+                k: 3
+                seed: 42
+                epsilon: 0.05
 
             - files: ['datasets/wine.csv', 'datasets/cloud.csv',
                       'datasets/wine_qual.csv', 'datasets/isolet.csv',
                       'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                       'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                       'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-              options: '-k 3 -s 42 -e 0.10'
+              options:
+                k: 3
+                seed: 42
+                epsilon: 0.10
 
             - files: ['datasets/wine.csv', 'datasets/cloud.csv',
                       'datasets/wine_qual.csv', 'datasets/isolet.csv',
                       'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                       'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                       'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-              options: '-k 3 -s 42 -e 0.15'
+              options:
+                k: 3
+                seed: 42
+                epsilon: 0.15
 
             - files: ['datasets/wine.csv', 'datasets/cloud.csv',
                       'datasets/wine_qual.csv', 'datasets/isolet.csv',
                       'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                       'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                       'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-              options: '-k 3 -s 42 -e 0.20'
+              options:
+                k: 3
+                seed: 42
+                epsilon: 0.20
 
             - files: ['datasets/wine.csv', 'datasets/cloud.csv',
                       'datasets/wine_qual.csv', 'datasets/isolet.csv',
                       'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                       'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                       'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-              options: '-k 3 -s 42 -e 0.25'
+              options:
+                k: 3
+                seed: 42
+                epsilon: 0.25
 
             - files: ['datasets/wine.csv', 'datasets/cloud.csv',
                       'datasets/wine_qual.csv', 'datasets/isolet.csv',
                       'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                       'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                       'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-              options: '-k 3 -s 42 -S'
+              options:
+                k: 3
+                seed: 42
+                single_mode: True
 
             - files: ['datasets/wine.csv', 'datasets/cloud.csv',
                       'datasets/wine_qual.csv', 'datasets/isolet.csv',
                       'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                       'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                       'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-              options: '-k 3 -s 42 --tree_type=cover'
+              options:
+                k: 3
+                seed: 42
+                tree_type: cover
 
             - files: ['datasets/wine.csv', 'datasets/cloud.csv',
                       'datasets/wine_qual.csv', 'datasets/isolet.csv',
                       'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                       'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                       'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-              options: '-k 3 -s 42 --tree_type=cover -S'
+              options:
+                k: 3
+                seed: 42
+                tree_type: cover
+                single_mode: True
 
             - files: ['datasets/wine.csv', 'datasets/cloud.csv',
                       'datasets/wine_qual.csv', 'datasets/isolet.csv',
                       'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                       'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                       'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-              options: '-k 3 -s 42 -N'
+              options:
+                k: 3
+                seed: 42
+                naive_mode: True
+
     ALLKFN:
         run: ['metric']
         script: methods/mlpack/allkfn.py
@@ -351,21 +436,27 @@ methods:
                       'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                       'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                       'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-              options: '-k 3'
+              options:
+                k: 3
 
             - files: ['datasets/wine.csv', 'datasets/cloud.csv',
                       'datasets/wine_qual.csv', 'datasets/isolet.csv',
                       'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                       'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                       'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-              options: '-k 3 -s'
+              options:
+                k: 3
+                single_mode: True
 
             - files: ['datasets/wine.csv', 'datasets/cloud.csv',
                       'datasets/wine_qual.csv', 'datasets/isolet.csv',
                       'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                       'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                       'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-              options: '-k 3 -N'
+              options:
+                k: 3
+                naive_mode: True
+
     ALLKRANN:
         run: ['metric']
         script: methods/mlpack/allkrann.py
@@ -376,35 +467,49 @@ methods:
                       'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                       'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                       'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-              options: '-k 3 -T 10'
+              options:
+                k: 3
+                tau: 10
 
             - files: ['datasets/wine.csv', 'datasets/cloud.csv',
                       'datasets/wine_qual.csv', 'datasets/isolet.csv',
                       'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                       'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                       'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-              options: '-k 3 -T 10 -N'
+              options:
+                k: 3
+                tau: 10
+                naive_mode: True
 
             - files: ['datasets/wine.csv', 'datasets/cloud.csv',
                       'datasets/wine_qual.csv', 'datasets/isolet.csv',
                       'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                       'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                       'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-              options: '-k 3 -T 10 -s'
+              options:
+                k: 3
+                tau: 10
+                single_mode: True
 
             - files: ['datasets/wine.csv', 'datasets/cloud.csv',
                       'datasets/wine_qual.csv', 'datasets/isolet.csv',
                       'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                       'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                       'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-              options: '-k 3 -T 10 -L'
+              options:
+                k: 3
+                tau: 10
+                sample_at_leaves: True
 
             - files: ['datasets/wine.csv', 'datasets/cloud.csv',
                       'datasets/wine_qual.csv', 'datasets/isolet.csv',
                       'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                       'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                       'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-              options: '-k 3 -T 10 -X'
+              options:
+                k: 3
+                tau: 10
+                first_leaf_exact: True
     RANGESEARCH:
         run: ['metric']
         script: methods/mlpack/range_search.py
@@ -415,21 +520,26 @@ methods:
                       'datasets/madelon_X.csv', 'datasets/arcene_X.csv',
                       'datasets/corel-histogram.csv', 'datasets/isolet.csv',
                       'datasets/covtype.csv', 'datasets/Twitter.csv']
-              options: '-M 0.02'
+              options:
+                max: 0.02
 
             - files: ['datasets/wine.csv', 'datasets/ionosphere.csv',
                       'datasets/cloud.csv', 'datasets/vehicle.csv',
                       'datasets/madelon_X.csv', 'datasets/arcene_X.csv',
                       'datasets/corel-histogram.csv', 'datasets/isolet.csv',
                       'datasets/covtype.csv', 'datasets/Twitter.csv']
-              options: '-M 0.02 -N'
+              options:
+                max: 0.02
+                naive_mode: True
 
             - files: ['datasets/wine.csv', 'datasets/ionosphere.csv',
                       'datasets/cloud.csv', 'datasets/vehicle.csv',
                       'datasets/madelon_X.csv', 'datasets/arcene_X.csv',
                       'datasets/corel-histogram.csv', 'datasets/isolet.csv',
                       'datasets/covtype.csv', 'datasets/Twitter.csv']
-              options: '-M 0.02 -s'
+              options:
+                max: 0.02
+                single_mode: True
     GMM:
         run: ['metric']
         script: methods/mlpack/gmm.py
@@ -440,14 +550,19 @@ methods:
                       'datasets/vehicle.csv', 'datasets/USCensus1990.csv',
                       'datasets/optdigits.csv', 'datasets/isolet.csv',
                       'datasets/TomsHardware.csv', 'datasets/covtype.csv']
-              options: '-s 42'
+              options:
+                gaussians: 3
+                seed: 42
 
             - files: ['datasets/artificial_2DSignal.csv', 'datasets/artificial_5DSignal.csv',
                       'datasets/iris.csv', 'datasets/wine.csv',
                       'datasets/vehicle.csv', 'datasets/USCensus1990.csv',
                       'datasets/optdigits.csv', 'datasets/isolet.csv',
                       'datasets/TomsHardware.csv', 'datasets/covtype.csv']
-              options: '-P -s 42'
+              options:
+                gaussians: 3
+                seed: 42
+                no_force_positive: True
     DET:
         run: ['metric']
         script: methods/mlpack/det.py
@@ -458,7 +573,9 @@ methods:
 
             - files: ['datasets/iris.csv', 'datasets/cloud.csv',
                      ['datasets/madelon_train.csv', 'datasets/madelon_test.csv'] ]
-              options: '-f 20'
+              options:
+                folds: 20
+
     EMST:
         run: ['metric']
         script: methods/mlpack/emst.py
@@ -470,7 +587,8 @@ methods:
 
             - files: ['datasets/iris.csv', 'datasets/vehicle.csv',
                       'datasets/waveform.csv']
-              options: '-n'
+              options:
+                naive_mode: True
 
     LinearRegression:
         run: ['metric']
@@ -482,60 +600,95 @@ methods:
                         ['datasets/ticdata2000.csv'], ['datasets/TomsHardware.csv'],
                         ['datasets/madelon_train.csv', 'datasets/madelon_test.csv'],
                         ['datasets/arcene_train.csv', 'datasets/arcene_test.csv'] ]
+
     LocalCoordinateCoding:
         run: ['metric']
         script: methods/mlpack/local_coordinate_coding.py
         format: [csv, txt]
         datasets:
-             - files: ['datasets/pendigits.csv']
-               options: '-k 12 -s 42'
+            - files: ['datasets/pendigits.csv']
+              options:
+                atoms: 12
+                seed: 42
 
-             - files: ['datasets/pendigits.csv']
-               options: '-k 12 -s 42 -N'
+            - files: ['datasets/pendigits.csv']
+              options:
+                atoms: 12
+                seed: 42
+                normalize: True
     SparseCoding:
         run: ['metric']
         script: methods/mlpack/sparse_coding.py
         format: [csv, txt]
         datasets:
             - files: ['datasets/pendigits.csv']
-              options: '-k 12 -s 42 -n 100'
+              options:
+                atoms: 12
+                seed: 42
+                max_iterations: 100
 
             - files: ['datasets/pendigits.csv']
-              options: '-k 12 -s 42'
+              options:
+                atoms: 12
+                seed: 42
 
             - files: ['datasets/pendigits.csv']
-              options: '-k 12 -s 42 -N'
+              options:
+                atoms: 12
+                seed: 42
+                normalize: True
     FastMKS:
         run: ['metric']
         script: methods/mlpack/fastmks.py
         format: [csv, txt]
         datasets:
             - files: ['datasets/optdigits.csv']
-              options: '-k 1 -K linear'
+              options:
+                k: 1
+                kernel: linear
 
             - files: ['datasets/optdigits.csv']
-              options: '-k 10 -K linear'
+              options:
+                k: 10
+                kernel: linear
 
             - files: ['datasets/optdigits.csv']
-              options: '-k 10 -S -K linear'
+              options:
+                k: 10
+                single_mode: True
+                kernel: linear
 
             - files: ['datasets/optdigits.csv']
-              options: '-k 10 -K polynomial -d 10'
+              options:
+                k: 10
+                kernel: polynomial
+                degree: 10
 
             - files: ['datasets/optdigits.csv']
-              options: '-k 10 -K hyptan'
+              options:
+                k: 10
+                kernel: hyptan
 
             - files: ['datasets/optdigits.csv']
-              options: '-k 10 -K cosine'
+              options:
+                k: 10
+                kernel: cosine
 
             - files: ['datasets/optdigits.csv']
-              options: '-k 10 -K gaussian'
+              options:
+                k: 10
+                kernel: gaussian
 
             - files: ['datasets/optdigits.csv']
-              options: '-k 10 -K epanechnikov'
+              options:
+                k: 10
+                kernel: epanechnikov
 
             - files: ['datasets/optdigits.csv']
-              options: '-k 10 -K triangular'
+              options:
+                k: 10
+                kernel: triangular
+
     NCA:
         run: ['metric']
         script: methods/mlpack/nca.py
@@ -550,7 +703,10 @@ methods:
                       'datasets/covtype.csv', 'datasets/1000000-10-randu.csv',
                       'datasets/mnist_all.csv', 'datasets/Twitter.csv',
                       'datasets/tinyImages100k.csv', 'datasets/yearpredictionmsd.csv']
-              options: '-n 2000 -O sgd -s 42'
+              options:
+                max_iterations: 2000
+                optimizer: sgd
+                seed: 42
 
             - files: ['datasets/iris_train.csv',
                       ['datasets/diabetes_X.csv', 'datasets/diabetes_y.csv'],
@@ -561,7 +717,10 @@ methods:
                       'datasets/covtype.csv', 'datasets/1000000-10-randu.csv',
                       'datasets/mnist_all.csv', 'datasets/Twitter.csv',
                       'datasets/tinyImages100k.csv', 'datasets/yearpredictionmsd.csv']
-              options: '-n 2000 -O lbfgs -s 42'
+              options:
+                max_iterations: 2000
+                optimizer: lbfgs
+                seed: 42
 
             - files: ['datasets/iris_train.csv',
                       ['datasets/diabetes_X.csv', 'datasets/diabetes_y.csv'],
@@ -572,12 +731,21 @@ methods:
                       'datasets/covtype.csv', 'datasets/1000000-10-randu.csv',
                       'datasets/mnist_all.csv', 'datasets/Twitter.csv',
                       'datasets/tinyImages100k.csv', 'datasets/yearpredictionmsd.csv']
-              options: '-n 2000 -O lbfgs -s 42 -w 0.5'
+              options:
+                max_iterations: 2000
+                optimizer: lbfgs
+                seed: 42
+                wolfe: 0.5
 
             - files: ['datasets/iris_train.csv', ['datasets/diabetes_X.csv', 'datasets/diabetes_y.csv'],
                       'datasets/wine.csv', 'datasets/ionosphere.csv',
                       'datasets/shuttle_train.csv', 'datasets/madelon_train.csv']
-              options: '-n 2000 -O lbfgs -s 42 -w 0.5 -B 5'
+              options:
+                max_iterations: 2000
+                optimizer: lbfgs
+                seed: 42
+                wolfe: 0.5
+                num_basis: 5
 
             - files: ['datasets/iris_train.csv',
                       ['datasets/diabetes_X.csv', 'datasets/diabetes_y.csv'],
@@ -588,7 +756,11 @@ methods:
                       'datasets/covtype.csv', 'datasets/1000000-10-randu.csv',
                       'datasets/mnist_all.csv', 'datasets/Twitter.csv',
                       'datasets/tinyImages100k.csv', 'datasets/yearpredictionmsd.csv']
-              options: '-n 2000 -O lbfgs -s 42 -B 5'
+              options:
+                max_iterations: 2000
+                optimizer: lbfgs
+                seed: 42
+                num_basis: 5
 
             - files: ['datasets/iris_train.csv',
                       ['datasets/diabetes_X.csv', 'datasets/diabetes_y.csv'],
@@ -599,30 +771,44 @@ methods:
                       'datasets/covtype.csv', 'datasets/1000000-10-randu.csv',
                       'datasets/mnist_all.csv', 'datasets/Twitter.csv',
                       'datasets/tinyImages100k.csv', 'datasets/yearpredictionmsd.csv']
-              options: '-n 2000 -N -s 42'
+              options:
+                max_iterations: 2000
+                normalize: True
+                seed: 42
+
     HMMTRAIN:
         run: ['metric']
         script: methods/mlpack/hmm_train.py
         format: [csv, txt]
         datasets:
             - files: ['datasets/artificial_2DSignal.csv']
-              options: '-t gaussian -n 20 -s 42'
+              options:
+                type: gaussian
+                states: 20
+                seed: 42
 
             - files: ['datasets/artificial_1DSignal.csv']
-              options: '-t discrete -n 20 -s 42'
+              options:
+                type: discrete
+                states: 20
+                seed: 42
+
     HMMGENERATE:
         run: ['metric']
         script: methods/mlpack/hmm_generate.py
         format: [csv, txt, xml]
         datasets:
             - files: ['datasets/artificial_2DSignal_hmm.xml']
-              options: '-l 10000'
+              options:
+                length: 10000
+
     HMMLOGLIK:
        run: ['metric']
        script: methods/mlpack/hmm_loglik.py
        format: [csv, txt, xml]
        datasets:
            - files: [ ['datasets/artificial_2DSignal.csv', 'datasets/artificial_2DSignal_hmm.xml'] ]
+
     HMMVITERBI:
        run: ['metric']
        iteration: 3
@@ -662,7 +848,8 @@ methods:
                       'datasets/covtype.csv', 'datasets/1000000-10-randu.csv',
                       'datasets/mnist_all.csv', 'datasets/Twitter.csv',
                       'datasets/tinyImages100k.csv', 'datasets/yearpredictionmsd.csv']
-              options: '-d 2'
+              options:
+                new_dimensionality: 2
 
             - files: ['datasets/iris.csv', 'datasets/wine.csv',
                       'datasets/cities.csv', 'datasets/diabetes_X.csv',
@@ -674,7 +861,9 @@ methods:
                       'datasets/covtype.csv', 'datasets/1000000-10-randu.csv',
                       'datasets/mnist_all.csv', 'datasets/Twitter.csv',
                       'datasets/tinyImages100k.csv', 'datasets/yearpredictionmsd.csv']
-              options: '-d 2 -s'
+              options:
+                new_dimensionality: 2
+                scaled: True
 
     PERCEPTRON:
         run: ['metric']
@@ -693,7 +882,8 @@ methods:
                        ['datasets/abalone7_train.csv', 'datasets/abalone7_test.csv', 'datasets/abalone7_labels.csv'],
                        ['datasets/satellite_train.csv', 'datasets/satellite_test.csv', 'datasets/satellite_labels.csv'],
                        ['datasets/ecoli_train.csv', 'datasets/ecoli_test.csv', 'datasets/ecoli_labels.csv'] ]
-              options: '-n 10000'
+              options:
+                max_iterations: 10000
 
     NMF:
         run: ['metric']
@@ -706,7 +896,11 @@ methods:
                       'datasets/TomsHardware.csv', 'datasets/pendigits.csv',
                       'datasets/isolet.csv', 'datasets/mnist_all.csv',
                       'datasets/tinyImages100k.csv', 'datasets/yearpredictionmsd.csv']
-              options: '-r 6 -s 42 -u multdist'
+              options:
+                rank: 6
+                seed: 42
+                update_rules: multdist
+
     KMEANS:
         run: ['metric']
         iteration: 3
@@ -714,31 +908,39 @@ methods:
         format: [csv, txt, arff]
         datasets:
             - files: [ ['datasets/waveform.csv', 'datasets/waveform_centroids.csv'] ]
-              options: '-c 2'
+              options:
+                clusters: 2
 
             - files: [ ['datasets/wine.csv', 'datasets/wine_centroids.csv'],
                        ['datasets/iris.csv', 'datasets/iris_centroids.csv'] ]
-              options: '-c 3'
+              options:
+                clusters: 3
 
             - files: [ ['datasets/cloud.csv', 'datasets/cloud_centroids.csv'] ]
-              options: '-c 5'
+              options:
+                clusters: 5
 
             - files: [ ['datasets/USCensus1990.csv', 'datasets/USCensus1990_centroids.csv'] ]
-              options: '-c 6'
+              options:
+                clusters: 6
 
             - files: [ ['datasets/covtype.csv', 'datasets/covtype_centroids.csv'],
                        ['datasets/wine_qual.csv', 'datasets/wine_qual_centroids.csv'] ]
-              options: '-c 7'
+              options:
+                clusters: 7
 
             - files: [ ['datasets/isolet.csv', 'datasets/isolet_centroids.csv'] ]
-              options: '-c 26'
+              options:
+                clusters: 26
 
             - files: [ ['datasets/mnist_all.csv', 'datasets/mnist_all_centroids.csv'],
                        ['datasets/corel-histogram.csv', 'datasets/corel-histogram_centroids.csv'] ]
-              options: '-c 10'
+              options:
+                clusters: 10
 
             - files: [ ['datasets/1000000-10-randu.csv'] ]
-              options: '-c 75'
+              options:
+                clusters: 75
     NBC:
         run: ['metric']
         iteration: 3
@@ -759,14 +961,20 @@ methods:
                       'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                       'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                       'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-              options: '-k 3 -s 42'
+              options:
+                k: 3
+                seed: 42
 
             - files: ['datasets/wine.csv', 'datasets/cloud.csv',
                       'datasets/wine_qual.csv', 'datasets/isolet.csv',
                       'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                       'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                       'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-              options: '-k 3 -s 42 -N'
+              options:
+                k: 3
+                seed: 42
+                naive_mode: True
+
     RANGESEARCH:
         run: ['metric']
         iteration: 3
@@ -778,7 +986,9 @@ methods:
                       'datasets/madelon_X.csv', 'datasets/arcene_X.csv',
                       'datasets/corel-histogram.csv', 'datasets/isolet.csv',
                       'datasets/covtype.csv', 'datasets/Twitter.csv']
-              options: '-M 0.02'
+              options:
+                max: 0.02
+
     LinearRegression:
         run: ['metric']
         iteration: 3
@@ -797,7 +1007,26 @@ methods:
         format: [csv, txt, xml]
         datasets:
             - files: ['datasets/artificial_2DSignal_hmm.xml']
-              options: '-l 10000'
+              options:
+                length: 10000
+
+    LogisticRegression:
+            run: ['metric']
+            script: methods/matlab/logistic_regression.py
+            format: [csv, txt, arff]
+            datasets:
+                - files: [ ['datasets/oilspill_train.csv', 'datasets/oilspill_test.csv', 'datasets/oilspill_labels.csv'],
+                           ['datasets/scene_train.csv', 'datasets/scene_test.csv', 'datasets/scene_labels.csv'],
+                           ['datasets/webpage_train.csv', 'datasets/webpage_test.csv', 'datasets/webpage_labels.csv'],
+                           ['datasets/isolet_train.csv', 'datasets/isolet_test.csv', 'datasets/isolet_labels.csv'],
+                           ['datasets/mammography_train.csv', 'datasets/mammography_test.csv', 'datasets/mammography_labels.csv'],
+                           ['datasets/reuters_train.csv', 'datasets/reuters_test.csv', 'datasets/reuters_labels.csv'],
+                           ['datasets/abalone19_train.csv', 'datasets/abalone19_test.csv', 'datasets/abalone19_labels.csv'],
+                           ['datasets/sickEuthyroid_train.csv', 'datasets/sickEuthyroid_test.csv', 'datasets/sickEuthyroid_labels.csv'],
+                           ['datasets/abalone7_train.csv', 'datasets/abalone7_test.csv', 'datasets/abalone7_labels.csv'],
+                           ['datasets/satellite_train.csv', 'datasets/satellite_test.csv', 'datasets/satellite_labels.csv'],
+                           ['datasets/ecoli_train.csv', 'datasets/ecoli_test.csv', 'datasets/ecoli_labels.csv'] ]
+
     HMMVITERBI:
        run: ['metric']
        iteration: 3
@@ -817,7 +1046,7 @@ methods:
         datasets:
             - files: ['datasets/iris.csv', 'datasets/wine.csv',
                       'datasets/cities.csv', 'datasets/diabetes_X.csv']
-                      
+
     PCA:
         run: ['metric']
         iteration: 3
@@ -845,7 +1074,8 @@ methods:
                       'datasets/covtype.csv', 'datasets/1000000-10-randu.csv',
                       'datasets/mnist_all.csv', 'datasets/Twitter.csv',
                       'datasets/tinyImages100k.csv', 'datasets/yearpredictionmsd.csv']
-              options: '-d 2'
+              options:
+                new_dimensionality: 2
 
             - files: ['datasets/iris.csv', 'datasets/wine.csv',
                       'datasets/cities.csv', 'datasets/diabetes_X.csv',
@@ -857,7 +1087,9 @@ methods:
                       'datasets/covtype.csv', 'datasets/1000000-10-randu.csv',
                       'datasets/mnist_all.csv', 'datasets/Twitter.csv',
                       'datasets/tinyImages100k.csv', 'datasets/yearpredictionmsd.csv']
-              options: '-d 2 -s'
+              options:
+                new_dimensionality: 2
+                whiten: True
 
     PERCEPTRON:
         run: ['metric']
@@ -876,7 +1108,8 @@ methods:
                        ['datasets/abalone7_train.csv', 'datasets/abalone7_test.csv', 'datasets/abalone7_labels.csv'],
                        ['datasets/satellite_train.csv', 'datasets/satellite_test.csv', 'datasets/satellite_labels.csv'],
                        ['datasets/ecoli_train.csv', 'datasets/ecoli_test.csv', 'datasets/ecoli_labels.csv'] ]
-              options: '-n 10000'
+              options:
+                max_iterations: 10000
 
     ADABOOST:
             run: ['metric']
@@ -985,7 +1218,13 @@ methods:
                            ['datasets/abalone7_train.csv', 'datasets/abalone7_test.csv', 'datasets/abalone7_labels.csv'],
                            ['datasets/satellite_train.csv', 'datasets/satellite_test.csv', 'datasets/satellite_labels.csv'],
                            ['datasets/ecoli_train.csv', 'datasets/ecoli_test.csv', 'datasets/ecoli_labels.csv'] ]
-                  options: '-e 50 -c entropy -d 10 --min_samples_split 4 --min_samples_leaf 2 --n_jobs 2'
+                  options:
+                    num_trees: 50
+                    max_depth: 10
+                    fitness_function: entropy
+                    minimum_samples_split: 4
+                    minimum_leaf_size: 2
+                    num_jobs: 2
     SVM:
             run: ['metric']
             script: methods/scikit/svm.py
@@ -1034,8 +1273,8 @@ methods:
                       'datasets/TomsHardware.csv', 'datasets/pendigits.csv',
                       'datasets/isolet.csv', 'datasets/mnist_all.csv',
                       'datasets/tinyImages100k.csv', 'datasets/yearpredictionmsd.csv']
-              options: '-r 6 -u alspgrad'
-              
+              options:
+                rank: 6
 
     KMEANS:
         run: ['metric']
@@ -1044,31 +1283,39 @@ methods:
         format: [csv, txt, arff]
         datasets:
             - files: [ ['datasets/waveform.csv', 'datasets/waveform_centroids.csv'] ]
-              options: '-c 2'
+              options:
+                clusters: 2
 
             - files: [ ['datasets/wine.csv', 'datasets/wine_centroids.csv'],
                        ['datasets/iris.csv', 'datasets/iris_centroids.csv'] ]
-              options: '-c 3'
+              options:
+                clusters: 3
 
             - files: [ ['datasets/cloud.csv', 'datasets/cloud_centroids.csv'] ]
-              options: '-c 5'
+              options:
+                clusters: 5
 
             - files: [ ['datasets/USCensus1990.csv', 'datasets/USCensus1990_centroids.csv'] ]
-              options: '-c 6'
+              options:
+                clusters: 6
 
             - files: [ ['datasets/covtype.csv', 'datasets/covtype_centroids.csv'],
                        ['datasets/wine_qual.csv', 'datasets/wine_qual_centroids.csv'] ]
-              options: '-c 7'
+              options:
+                clusters: 7
 
             - files: [ ['datasets/isolet.csv', 'datasets/isolet_centroids.csv'] ]
-              options: '-c 26'
+              options:
+                clusters: 26
 
             - files: [ ['datasets/mnist_all.csv', 'datasets/mnist_all_centroids.csv'],
                        ['datasets/corel-histogram.csv', 'datasets/corel-histogram_centroids.csv'] ]
-              options: '-c 10'
+              options:
+                clusters: 10
 
             - files: [ ['datasets/1000000-10-randu.csv'] ]
-              options: '-c 75'
+              options:
+                centroids: 75
     NBC:
         run: ['metric']
         iteration: 3
@@ -1090,7 +1337,8 @@ methods:
                       'datasets/arcene_X.csv', 'datasets/madelon_X.csv',
                       'datasets/pendigits.csv', 'datasets/isolet.csv',
                       'datasets/covtype.csv']
-              options: '-k linear'
+              options:
+                kernel: linear
 
             - files: ['datasets/circle_data.csv', 'datasets/stock.csv',
                       'datasets/abalone.csv', 'datasets/bank8FM.csv',
@@ -1098,7 +1346,8 @@ methods:
                       'datasets/arcene_X.csv', 'datasets/madelon_X.csv',
                       'datasets/pendigits.csv', 'datasets/isolet.csv',
                       'datasets/covtype.csv']
-              options: '-k polynomial'
+              options:
+                kernel: polynomial
 
             - files: ['datasets/circle_data.csv', 'datasets/stock.csv',
                       'datasets/abalone.csv', 'datasets/bank8FM.csv',
@@ -1106,7 +1355,8 @@ methods:
                       'datasets/arcene_X.csv', 'datasets/madelon_X.csv',
                       'datasets/pendigits.csv', 'datasets/isolet.csv',
                       'datasets/covtype.csv']
-              options: '-k hyptan'
+              options:
+                kernel: hyptan
     ANN:
         run: ['metric']
         script: methods/scikit/LSHForest.py
@@ -1134,7 +1384,8 @@ methods:
                        ['datasets/cosExp_X.csv', 'datasets/cosExp_y.csv'],
                        ['datasets/arcene_X.csv', 'datasets/arcene_y.csv'],
                        ['datasets/madelon_X.csv', 'datasets/madelon_y.csv'] ]
-              options: '-l 0.01'
+              options:
+                lambda1: 0.01
 
     LASSO:
         run: ['metric']
@@ -1146,7 +1397,8 @@ methods:
                        ['datasets/cosExp_X.csv', 'datasets/cosExp_y.csv'],
                        ['datasets/arcene_X.csv', 'datasets/arcene_y.csv'],
                        ['datasets/madelon_X.csv', 'datasets/madelon_y.csv'] ]
-              options: '-l 0.01'
+              # script does not accept any options currently
+              # options: '-l 0.01'
 
     SVR:
         run: ['metric']
@@ -1157,7 +1409,10 @@ methods:
             - files: [ ['datasets/diabetes.csv'],
                        ['datasets/cosExp.csv'],
                        ['datasets/TomsHardware.csv']]
-              options: '-c 1.0 -e 1.0 -g 0.1'
+              options:
+                c: 1.0
+                epsilon: 1.0
+                gamma: 0.1
 
     ALLKNN:
         run: ['metric']
@@ -1170,7 +1425,8 @@ methods:
                       'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                       'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                       'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-              options: '-k 3 -s 42'
+              options:
+                k: 3 # random seed cannot be set
     GMM:
         run: ['metric']
         iteration: 3
@@ -1182,6 +1438,9 @@ methods:
                       'datasets/vehicle.csv', 'datasets/USCensus1990.csv',
                       'datasets/optdigits.csv', 'datasets/isolet.csv',
                       'datasets/TomsHardware.csv', 'datasets/covtype.csv']
+              options:
+                gaussians: 3
+
     LinearRegression:
         run: ['metric']
         iteration: 3
@@ -1200,28 +1459,41 @@ methods:
         format: [csv, txt]
         datasets:
             - files: ['datasets/pendigits.csv']
-              options: '-k 12 -s 42 -n 100'
+              options:
+                atoms: 12
+                seed: 42
+                max_iterations: 100
 
             - files: ['datasets/pendigits.csv']
-              options: '-k 12 -s 42'
+              options:
+                atoms: 12
+                seed: 42
 
             - files: ['datasets/pendigits.csv']
-              options: '-k 12 -s 42 -N'
+              options:
+                atoms: 12
+                seed: 42
+                normalize: True
+
     LinearRidgeRegression:
-        run: ['metric','metric']
+        run: ['metric']
         iteration: 3
         script: methods/scikit/linear_ridge_regression.py
         format: [csv, txt]
         datasets:
             - files: [ ['datasets/sickEuthyroid_train.csv', 'datasets/sickEuthyroid_test.csv', 'datasets/sickEuthyroid_labels.csv'],
                        ['datasets/webpage_train.csv', 'datasets/webpage_test.csv', 'datasets/webpage_labels.csv'] ]
-              options: '-t 1.0'
+              options:
+                alpha: 1.0
             - files: [ ['datasets/ecoli_train.csv', 'datasets/ecoli_test.csv', 'datasets/ecoli_labels.csv'],
                        ['datasets/mammography_train.csv', 'datasets/mammography_test.csv', 'datasets/mammography_labels.csv'] ]
-              options: '-t 5.0'
+              options:
+                alpha: 5.0
             - files: [ ['datasets/abalone7_train.csv', 'datasets/abalone7_test.csv', 'datasets/abalone7_labels.csv'],
                        ['datasets/abalone19_train.csv', 'datasets/abalone19_test.csv', 'datasets/abalone19_labels.csv'] ]
-              options: '-t 50.0'
+              options:
+                alpha: 50.0
+
     LogisticRegression:
         run: ['metric']
         iteration: 3
@@ -1272,7 +1544,8 @@ methods:
                       'datasets/covtype.csv', 'datasets/1000000-10-randu.csv',
                       'datasets/mnist_all.csv', 'datasets/Twitter.csv',
                       'datasets/tinyImages100k.csv', 'datasets/yearpredictionmsd.csv']
-              options: '-d 2'
+              options:
+                new_dimensionality: 2
 
             - files: ['datasets/iris.csv', 'datasets/wine.csv',
                       'datasets/cities.csv', 'datasets/diabetes_X.csv',
@@ -1284,7 +1557,9 @@ methods:
                       'datasets/covtype.csv', 'datasets/1000000-10-randu.csv',
                       'datasets/mnist_all.csv', 'datasets/Twitter.csv',
                       'datasets/tinyImages100k.csv', 'datasets/yearpredictionmsd.csv']
-              options: '-d 2 -s'
+              options:
+                new_dimensionality: 2
+                whiten: True
 
     KMEANS:
         run: ['metric']
@@ -1293,31 +1568,39 @@ methods:
         format: [csv, txt, arff]
         datasets:
             - files: [ ['datasets/waveform.csv', 'datasets/waveform_centroids.csv'] ]
-              options: '-c 2'
+              options:
+                clusters: 2
 
             - files: [ ['datasets/wine.csv', 'datasets/wine_centroids.csv'],
                        ['datasets/iris.csv', 'datasets/iris_centroids.csv'] ]
-              options: '-c 3'
+              options:
+                clusters: 3
 
             - files: [ ['datasets/cloud.csv', 'datasets/cloud_centroids.csv'] ]
-              options: '-c 5'
+              options:
+                clusters: 5
 
             - files: [ ['datasets/USCensus1990.csv', 'datasets/USCensus1990_centroids.csv'] ]
-              options: '-c 6'
+              options:
+                clusters: 6
 
             - files: [ ['datasets/covtype.csv', 'datasets/covtype_centroids.csv'],
                        ['datasets/wine_qual.csv', 'datasets/wine_qual_centroids.csv'] ]
-              options: '-c 7'
+              options:
+                clusters: 7
 
             - files: [ ['datasets/isolet.csv', 'datasets/isolet_centroids.csv'] ]
-              options: '-c 26'
+              options:
+                clusters: 26
 
             - files: [ ['datasets/mnist_all.csv', 'datasets/mnist_all_centroids.csv'],
                        ['datasets/corel-histogram.csv', 'datasets/corel-histogram_centroids.csv'] ]
-              options: '-c 10'
+              options:
+                clusters: 10
 
             - files: [ ['datasets/1000000-10-randu.csv'] ]
-              options: '-c 75'
+              options:
+                clusters: 75
 
     ElasticNet:
             run: ['metric']
@@ -1363,7 +1646,9 @@ methods:
                 - files: [ ['datasets/iris_train.csv', 'datasets/iris_test.csv', 'datasets/iris_labels.csv'],
                            ['datasets/oilspill_train.csv', 'datasets/oilspill_test.csv', 'datasets/oilspill_labels.csv'],
                            ['datasets/scene_train.csv','datasets/scene_test.csv','datasets/scene_labels.csv'] ]
-                  options: '--stumps 10 -m 10'
+                  options:
+                    stumps: 10
+                    minimum_leaf_size: 10
 
                 - files: [ ['datasets/iris_train.csv','datasets/iris_test.csv','datasets/iris_labels.csv'],
                            ['datasets/oilspill_train.csv','datasets/oilspill_test.csv','datasets/oilspill_labels.csv'] ]
@@ -1403,7 +1688,8 @@ methods:
                            ['datasets/abalone7_train.csv', 'datasets/abalone7_test.csv', 'datasets/abalone7_labels.csv'],
                            ['datasets/satellite_train.csv', 'datasets/satellite_test.csv', 'datasets/satellite_labels.csv'],
                            ['datasets/ecoli_train.csv', 'datasets/ecoli_test.csv', 'datasets/ecoli_labels.csv'] ]
-                  options: '-n 10000'
+                  options:
+                    max_iterations: 10000
 
     SVM:
             run: ['metric']
@@ -1455,7 +1741,8 @@ methods:
                       'datasets/arcene_X.csv', 'datasets/madelon_X.csv',
                       'datasets/pendigits.csv', 'datasets/isolet.csv',
                       'datasets/covtype.csv']
-              options: '-k linear'
+              options:
+                kernel: linear
 
             - files: ['datasets/circle_data.csv', 'datasets/stock.csv',
                       'datasets/abalone.csv', 'datasets/bank8FM.csv',
@@ -1463,7 +1750,8 @@ methods:
                       'datasets/arcene_X.csv', 'datasets/madelon_X.csv',
                       'datasets/pendigits.csv', 'datasets/isolet.csv',
                       'datasets/covtype.csv']
-              options: '-k gaussian'
+              options:
+                kernel: gaussian
 
             - files: ['datasets/circle_data.csv', 'datasets/stock.csv',
                       'datasets/abalone.csv', 'datasets/bank8FM.csv',
@@ -1471,7 +1759,9 @@ methods:
                       'datasets/arcene_X.csv', 'datasets/madelon_X.csv',
                       'datasets/pendigits.csv', 'datasets/isolet.csv',
                       'datasets/covtype.csv']
-              options: '-k hyptan'
+              options:
+                kernel: hyptan
+
     LARS:
         run: ['metric']
         iteration: 3
@@ -1482,7 +1772,8 @@ methods:
                          ['datasets/cosExp_X.csv', 'datasets/cosExp_y.csv'],
                          ['datasets/arcene_X.csv', 'datasets/arcene_y.csv'],
                          ['datasets/madelon_X.csv', 'datasets/madelon_y.csv'] ]
-                options: '-l 0.01'
+                # TODO: add support for lambda to mlpy LARS
+                # options: '-l 0.01'
     ALLKNN:
         run: ['metric']
         iteration: 3
@@ -1494,7 +1785,8 @@ methods:
                       'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                       'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                       'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-              options: '-k 3 -s 42'
+              options:
+                k: 3 # random seed cannot be specified
 
     LinearRegression:
         run: ['metric']
@@ -1537,7 +1829,8 @@ methods:
                       'datasets/covtype.csv', 'datasets/1000000-10-randu.csv',
                       'datasets/mnist_all.csv', 'datasets/Twitter.csv',
                       'datasets/tinyImages100k.csv', 'datasets/yearpredictionmsd.csv']
-              options: '-d 2'
+              options:
+                new_dimensionality: 2
 
             - files: ['datasets/iris.csv', 'datasets/wine.csv',
                       'datasets/cities.csv', 'datasets/diabetes_X.csv',
@@ -1549,7 +1842,9 @@ methods:
                       'datasets/covtype.csv', 'datasets/1000000-10-randu.csv',
                       'datasets/mnist_all.csv', 'datasets/Twitter.csv',
                       'datasets/tinyImages100k.csv', 'datasets/yearpredictionmsd.csv']
-              options: '-d 2 -s'
+              options:
+                new_dimensionality: 2
+                whiten: True
     RANDOMFOREST:
         run: ['timing', 'metric']
         script: methods/shogun/random_forest.py
@@ -1567,6 +1862,8 @@ methods:
                        ['datasets/abalone7_train.csv', 'datasets/abalone7_test.csv', 'datasets/abalone7_labels.csv'],
                        ['datasets/satellite_train.csv', 'datasets/satellite_test.csv', 'datasets/satellite_labels.csv'],
                        ['datasets/ecoli_train.csv', 'datasets/ecoli_test.csv', 'datasets/ecoli_labels.csv'] ]
+              options:
+                num_trees: 50
 
     PERCEPTRON:
         run: ['metric']
@@ -1577,7 +1874,8 @@ methods:
                        ['datasets/optdigits_train.csv', 'datasets/optdigits_test.csv', 'datasets/optdigits_labels.csv'],
                        ['datasets/madelon_train.csv', 'datasets/madelon_test.csv'],
                        ['datasets/arcene_train.csv', 'datasets/arcene_test.csv'] ]
-              options: '-n 10000'
+              options:
+                max_iterations: 10000
 
     KMEANS:
         run: ['metric']
@@ -1586,31 +1884,39 @@ methods:
         format: [arff, csv, txt]
         datasets:
             - files: [ ['datasets/waveform.csv', 'datasets/waveform_centroids.csv'] ]
-              options: '-c 2'
+              options:
+                clusters: 2
 
             - files: [ ['datasets/wine.csv', 'datasets/wine_centroids.csv'],
                        ['datasets/iris.csv', 'datasets/iris_centroids.csv'] ]
-              options: '-c 3'
+              options:
+                clusters: 3
 
             - files: [ ['datasets/cloud.csv', 'datasets/cloud_centroids.csv'] ]
-              options: '-c 5'
+              options:
+                clusters: 5
 
             - files: [ ['datasets/USCensus1990.csv', 'datasets/USCensus1990_centroids.csv'] ]
-              options: '-c 6'
+              options:
+                clusters: 6
 
             - files: [ ['datasets/covtype.csv', 'datasets/covtype_centroids.csv'],
                        ['datasets/wine_qual.csv', 'datasets/wine_qual_centroids.csv'] ]
-              options: '-c 7'
+              options:
+                clusters: 7
 
             - files: [ ['datasets/isolet.csv', 'datasets/isolet_centroids.csv'] ]
-              options: '-c 26'
+              options:
+                clusters: 26
 
             - files: [ ['datasets/mnist_all.csv', 'datasets/mnist_all_centroids.csv'],
                        ['datasets/corel-histogram.csv', 'datasets/corel-histogram_centroids.csv'] ]
-              options: '-c 10'
+              options:
+                clusters: 10
 
             - files: [ ['datasets/1000000-10-randu.csv'] ]
-              options: '-c 75'
+              options:
+                clusters: 75
     KPCA:
         run: ['metric']
         iteration: 3
@@ -1623,7 +1929,8 @@ methods:
                       'datasets/arcene_X.csv', 'datasets/madelon_X.csv',
                       'datasets/pendigits.csv', 'datasets/isolet.csv',
                       'datasets/covtype.csv']
-              options: '-k linear'
+              options:
+                kernel: linear
 
             - files: ['datasets/circle_data.csv', 'datasets/stock.csv',
                       'datasets/abalone.csv', 'datasets/bank8FM.csv',
@@ -1631,7 +1938,8 @@ methods:
                       'datasets/arcene_X.csv', 'datasets/madelon_X.csv',
                       'datasets/pendigits.csv', 'datasets/isolet.csv',
                       'datasets/covtype.csv']
-              options: '-k gaussian'
+              options:
+                kernel: linear
 
             - files: ['datasets/circle_data.csv', 'datasets/stock.csv',
                       'datasets/abalone.csv', 'datasets/bank8FM.csv',
@@ -1639,7 +1947,8 @@ methods:
                       'datasets/arcene_X.csv', 'datasets/madelon_X.csv',
                       'datasets/pendigits.csv', 'datasets/isolet.csv',
                       'datasets/covtype.csv']
-              options: '-k polynomial'
+              options:
+                kernel: polynomial
 
             - files: ['datasets/circle_data.csv', 'datasets/stock.csv',
                       'datasets/abalone.csv', 'datasets/bank8FM.csv',
@@ -1647,7 +1956,8 @@ methods:
                       'datasets/arcene_X.csv', 'datasets/madelon_X.csv',
                       'datasets/pendigits.csv', 'datasets/isolet.csv',
                       'datasets/covtype.csv']
-              options: '-k hyptan'
+              options:
+                kernel: hyptan
     NBC:
         run: ['metric']
         iteration: 3
@@ -1669,7 +1979,8 @@ methods:
                       'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                       'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                       'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-              options: '-k 3 -s 42'
+              options:
+                k: 3
 
     GMM:
         run: ['metric']
@@ -1682,7 +1993,8 @@ methods:
                       'datasets/vehicle.csv', 'datasets/USCensus1990.csv',
                       'datasets/optdigits.csv', 'datasets/isolet.csv',
                       'datasets/TomsHardware.csv', 'datasets/covtype.csv']
-              options: '-s 42'
+              options:
+                gaussians: 3
 
     LinearRegression:
         run: ['metric']
@@ -1706,7 +2018,8 @@ methods:
                        ['datasets/cosExp_X.csv', 'datasets/cosExp_y.csv'],
                        ['datasets/arcene_X.csv', 'datasets/arcene_y.csv'],
                        ['datasets/madelon_X.csv', 'datasets/madelon_y.csv']]
-              options: '-l 0.01'
+              options:
+                lambda1: 0.01
 
     QDA:
             run: ['metric','metric']
@@ -1750,13 +2063,16 @@ methods:
         datasets:
             - files: [ ['datasets/sickEuthyroid_train.csv', 'datasets/sickEuthyroid_test.csv', 'datasets/sickEuthyroid_labels.csv'],
                        ['datasets/webpage_train.csv', 'datasets/webpage_test.csv', 'datasets/webpage_labels.csv'] ]
-              options: '-t 1.0'
+              options:
+                alpha: 1.0
             - files: [ ['datasets/ecoli_train.csv', 'datasets/ecoli_test.csv', 'datasets/ecoli_labels.csv'],
                        ['datasets/mammography_train.csv', 'datasets/mammography_test.csv', 'datasets/mammography_labels.csv'] ]
-              options: '-t 5.0'
+              options:
+                alpha: 5.0
             - files: [ ['datasets/abalone7_train.csv', 'datasets/abalone7_test.csv', 'datasets/abalone7_labels.csv'],
                        ['datasets/abalone19_train.csv', 'datasets/abalone19_test.csv', 'datasets/abalone19_labels.csv'] ]
-              options: '-t 50.0'
+              options:
+                alpha: 50.0
 
     SVR:
         run: ['metric']
@@ -1767,7 +2083,10 @@ methods:
             - files: [ ['datasets/diabetes.csv'],
                        ['datasets/cosExp.csv'],
                        ['datasets/TomsHardware.csv']]
-              options: '-c 1.0 -e 1.0 -g 0.1'
+              options:
+                c: 1.0
+                epsilon: 1.0
+                gamma: 0.1
 
     KNC:
             run: ['timing', 'metric']
@@ -1835,7 +2154,8 @@ methods:
                       'datasets/covtype.csv', 'datasets/1000000-10-randu.csv',
                       'datasets/mnist_all.csv', 'datasets/Twitter.csv',
                       'datasets/tinyImages100k.csv', 'datasets/yearpredictionmsd.csv']
-              options: '-d 2'
+              options:
+                new_dimensionality: 2
 
             - files: ['datasets/iris.csv', 'datasets/wine.csv',
                       'datasets/cities.csv', 'datasets/diabetes_X.csv',
@@ -1847,7 +2167,9 @@ methods:
                       'datasets/covtype.csv', 'datasets/1000000-10-randu.csv',
                       'datasets/mnist_all.csv', 'datasets/Twitter.csv',
                       'datasets/tinyImages100k.csv', 'datasets/yearpredictionmsd.csv']
-              options: '-d 2 -s'
+              options:
+                new_dimensionality: 2
+                whiten: True
     NBC:
         run: ['metric']
         iteration: 3
@@ -1864,31 +2186,39 @@ methods:
         format: [arff]
         datasets:
             - files: [ ['datasets/waveform.csv'] ]
-              options: '-c 2'
+              options:
+                clusters: 2
 
             - files: [ ['datasets/wine.csv'],
                        ['datasets/iris.csv'] ]
-              options: '-c 3'
+              options:
+                clusters: 3
 
             - files: [ ['datasets/cloud.csv'] ]
-              options: '-c 5'
+              options:
+                clusters: 5
 
             - files: [ ['datasets/USCensus1990.csv'] ]
-              options: '-c 6'
+              options:
+                clusters: 6
 
             - files: [ ['datasets/covtype.csv'],
                        ['datasets/wine_qual.csv'] ]
-              options: '-c 7'
+              options:
+                clusters: 7
 
             - files: [ ['datasets/isolet.csv'] ]
-              options: '-c 26'
+              options:
+                clusters: 26
 
             - files: [ ['datasets/mnist_all.csv'],
                        ['datasets/corel-histogram.csv'] ]
-              options: '-c 10'
+              options:
+                clusters: 10
 
             - files: [ ['datasets/1000000-10-randu.csv'] ]
-              options: '-c 75'
+              options:
+                clusters: 75
     ALLKNN:
         run: ['metric']
         iteration: 3
@@ -1900,7 +2230,9 @@ methods:
                       'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                       'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                       'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-              options: '-k 3 -s 42'
+              options:
+                k: 3
+                seed: 42
 
     LinearRegression:
         run: ['metric']
@@ -1928,49 +2260,69 @@ methods:
                         'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                         'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                         'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-                options: '-k 3 -s 42'
+                options:
+                  k: 3
+                  seed: 42
 
               - files: ['datasets/wine.csv', 'datasets/cloud.csv',
                         'datasets/wine_qual.csv', 'datasets/isolet.csv',
                         'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                         'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                         'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-                options: '-k 3 -s 42 -e 0.0'
+                options:
+                  k: 3
+                  seed: 42
+                  epsilon: 0.0
 
               - files: ['datasets/wine.csv', 'datasets/cloud.csv',
                         'datasets/wine_qual.csv', 'datasets/isolet.csv',
                         'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                         'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                         'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-                options: '-k 3 -s 42 -e 0.05'
+                options:
+                  k: 3
+                  seed: 42
+                  epsilon: 0.05
 
               - files: ['datasets/wine.csv', 'datasets/cloud.csv',
                         'datasets/wine_qual.csv', 'datasets/isolet.csv',
                         'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                         'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                         'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-                options: '-k 3 -s 42 -e 0.10'
+                options:
+                  k: 3
+                  seed: 42
+                  epsilon: 0.10
 
               - files: ['datasets/wine.csv', 'datasets/cloud.csv',
                         'datasets/wine_qual.csv', 'datasets/isolet.csv',
                         'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                         'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                         'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-                options: '-k 3 -s 42 -e 0.15'
+                options:
+                  k: 3
+                  seed: 42
+                  epsilon: 0.15
 
               - files: ['datasets/wine.csv', 'datasets/cloud.csv',
                         'datasets/wine_qual.csv', 'datasets/isolet.csv',
                         'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                         'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                         'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-                options: '-k 3 -s 42 -e 0.20'
+                options:
+                  k: 3
+                  seed: 42
+                  epsilon: 0.20
 
               - files: ['datasets/wine.csv', 'datasets/cloud.csv',
                         'datasets/wine_qual.csv', 'datasets/isolet.csv',
                         'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                         'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                         'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-                options: '-k 3 -s 42 -e 0.25'
+                options:
+                  k: 3
+                  seed: 42
+                  epsilon: 0.25
 ---
 #  FLANN:
 #  A Library for Fast Library for Approximate Nearest Neighbors
@@ -1986,49 +2338,69 @@ methods:
                         'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                         'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                         'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-                options: '-k 3 -s 42'
+                options:
+                  k: 3
+                  seed: 42
 
               - files: ['datasets/wine.csv', 'datasets/cloud.csv',
                         'datasets/wine_qual.csv', 'datasets/isolet.csv',
                         'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                         'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                         'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-                options: '-k 3 -s 42 -e 0.0'
+                options:
+                  k: 3
+                  seed: 42
+                  epsilon: 0.0
 
               - files: ['datasets/wine.csv', 'datasets/cloud.csv',
                         'datasets/wine_qual.csv', 'datasets/isolet.csv',
                         'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                         'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                         'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-                options: '-k 3 -s 42 -e 0.05'
+                options:
+                  k: 3
+                  seed: 42
+                  epsilon: 0.0
 
               - files: ['datasets/wine.csv', 'datasets/cloud.csv',
                         'datasets/wine_qual.csv', 'datasets/isolet.csv',
                         'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                         'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                         'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-                options: '-k 3 -s 42 -e 0.10'
+                options:
+                  k: 3
+                  seed: 42
+                  epsilon: 0.0
 
               - files: ['datasets/wine.csv', 'datasets/cloud.csv',
                         'datasets/wine_qual.csv', 'datasets/isolet.csv',
                         'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                         'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                         'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-                options: '-k 3 -s 42 -e 0.15'
+                options:
+                  k: 3
+                  seed: 42
+                  epsilon: 0.0
 
               - files: ['datasets/wine.csv', 'datasets/cloud.csv',
                         'datasets/wine_qual.csv', 'datasets/isolet.csv',
                         'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                         'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                         'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-                options: '-k 3 -s 42 -e 0.20'
+                options:
+                  k: 3
+                  seed: 42
+                  epsilon: 0.0
 
               - files: ['datasets/wine.csv', 'datasets/cloud.csv',
                         'datasets/wine_qual.csv', 'datasets/isolet.csv',
                         'datasets/corel-histogram.csv', 'datasets/covtype.csv',
                         'datasets/1000000-10-randu.csv', 'datasets/mnist_all.csv',
                         'datasets/Twitter.csv', 'datasets/tinyImages100k.csv']
-                options: '-k 3 -s 42 -e 0.25'
+                options:
+                  k: 3
+                  seed: 42
+                  epsilon: 0.0
 ---
 # MRPT: fast nearest neighbor search with random projection
 library: mrpt
@@ -2050,7 +2422,9 @@ methods:
                        ['datasets/abalone7_train.csv', 'datasets/abalone7_test.csv', 'datasets/abalone7_labels.csv'],
                        ['datasets/satellite_train.csv', 'datasets/satellite_test.csv', 'datasets/satellite_labels.csv'],
                        ['datasets/ecoli_train.csv', 'datasets/ecoli_test.csv', 'datasets/ecoli_labels.csv'] ]
-              options: '-k 10 -n 10'
+              options:
+                k: 10
+                num_trees: 10
 ---
 # Annoy: Approximate Nearest Neighbors Oh Yeah
 library: annoy
@@ -2072,7 +2446,9 @@ methods:
                        ['datasets/abalone7_train.csv', 'datasets/abalone7_test.csv', 'datasets/abalone7_labels.csv'],
                        ['datasets/satellite_train.csv', 'datasets/satellite_test.csv', 'datasets/satellite_labels.csv'],
                        ['datasets/ecoli_train.csv', 'datasets/ecoli_test.csv', 'datasets/ecoli_labels.csv'] ]
-              options: '-k 10 -n 10'
+              options:
+                k: 10
+                trees: 10
 ---
 # Nearpy
 library: nearpy
@@ -2104,28 +2480,36 @@ methods:
         format: [csv, txt, arff]
         datasets:
             - files: [ ['datasets/waveform.csv', 'datasets/waveform_centroids.csv'] ]
-              options: '-c 2'
+              options:
+                clusters: 2
 
             - files: [ ['datasets/wine.csv', 'datasets/wine_centroids.csv'],
                        ['datasets/iris.csv', 'datasets/iris_centroids.csv'] ]
-              options: '-c 3'
+              options:
+                clusters: 3
 
             - files: [ ['datasets/cloud.csv', 'datasets/cloud_centroids.csv'] ]
-              options: '-c 5'
+              options:
+                clusters: 5
 
             - files: [ ['datasets/USCensus1990.csv', 'datasets/USCensus1990_centroids.csv'] ]
-              options: '-c 6'
+              options:
+                clusters: 6
 
             - files: [ ['datasets/covtype.csv', 'datasets/covtype_centroids.csv'],
                        ['datasets/wine_qual.csv', 'datasets/wine_qual_centroids.csv'] ]
-              options: '-c 7'
+              options:
+                clusters: 7
 
             - files: [ ['datasets/isolet.csv', 'datasets/isolet_centroids.csv'] ]
-              options: '-c 26'
+              options:
+                clusters: 26
 
             - files: [ ['datasets/mnist_all.csv', 'datasets/mnist_all_centroids.csv'],
                        ['datasets/corel-histogram.csv', 'datasets/corel-histogram_centroids.csv'] ]
-              options: '-c 10'
+              options:
+                clusters: 10
+
     RANDOMFOREST:
         run: ['timing', 'metric']
         script: methods/milk/random_forest.py

--- a/methods/ann/allknn.py
+++ b/methods/ann/allknn.py
@@ -56,14 +56,26 @@ class ALLKNN(object):
   def RunMetrics(self, options):
     Log.Info("Perform ALLKNN.", self.verbose)
 
+    # Convert options dict to string to use.
+    optionsStr = ""
+    if "k" in options:
+      optionsStr = "-k " + str(options.pop("k"))
+    if "seed" in options:
+      optionsStr = optionsStr + " -s " + str(options.pop("seed"))
+    if "epsilon" in options:
+      optionsStr = optionsStr + " -e " + str(options.pop("epsilon"))
+    if len(options) > 0:
+      Log.Fatal("Unknown options: " + str(options))
+      raise Exception("unknown options")
+
     # If the dataset contains two files then the second file is the query file.
     # In this case we add this to the command line.
     if len(self.dataset) == 2:
       cmd = shlex.split(self.path + "allknn -r " + self.dataset[0] + " -q " +
-          self.dataset[1] + " -v " + options)
+          self.dataset[1] + " -v " + optionsStr)
     else:
       cmd = shlex.split(self.path + "allknn -r " + self.dataset +
-          " -v " + options)
+          " -v " + optionsStr)
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/annoy/ann.py
+++ b/methods/annoy/ann.py
@@ -65,14 +65,14 @@ class ANN(object):
         if (k < 1 or k > referenceData.shape[0]):
           Log.Fatal("Invalid k: " + k.group(1) + "; must be greater than 0"
               + " and less or equal than " + str(referenceData.shape[0]))
-        q.put(-1)
-        return -1
-      if not "trees" in options:
+          q.put(-1)
+          return -1
+      if not "num_trees" in options:
         Log.Fatal("Required option: Number of trees to build")
         q.put(-1)
         return -1
       else:
-        n = int(options.pop("trees"))
+        n = int(options.pop("num_trees"))
 
       if len(options) > 0:
         Log.Fatal("Unknown parameters: " + str(options))

--- a/methods/annoy/ann.py
+++ b/methods/annoy/ann.py
@@ -55,25 +55,28 @@ class ANN(object):
       queryData = np.genfromtxt(self.dataset[1], delimiter=',')
       train, label = SplitTrainData(self.dataset)
 
-      k = re.search("-k (\d+)", options)
-      n = re.search("-n (\d+)", options) # Number of trees.
-      if not k:
-          Log.Fatal("Required option: Number of furthest neighbors to find.")
-          q.put(-1)
-          return -1
+      # Parse options.
+      if not "k" in options:
+        Log.Fatal("Required option: Number of furthest neighbors to find.")
+        q.put(-1)
+        return -1
       else:
-          k = int(k.group(1))
-          if (k < 1 or k > referenceData.shape[0]):
-            Log.Fatal("Invalid k: " + k.group(1) + "; must be greater than 0"
+        k = int(options.pop("k"))
+        if (k < 1 or k > referenceData.shape[0]):
+          Log.Fatal("Invalid k: " + k.group(1) + "; must be greater than 0"
               + " and less or equal than " + str(referenceData.shape[0]))
-            q.put(-1)
-            return -1
-      if not n:
-            Log.Fatal("Required option: Number of trees to build")
-            q.put(-1)
-            return -1
+        q.put(-1)
+        return -1
+      if not "trees" in options:
+        Log.Fatal("Required option: Number of trees to build")
+        q.put(-1)
+        return -1
       else:
-            n=int(n.group(1))
+        n = int(options.pop("trees"))
+
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
 
       with totalTimer:
         # Get all the parameters.
@@ -107,7 +110,7 @@ class ANN(object):
   def RunMetrics(self, options):
     Log.Info("Perform Approximate Nearest Neighbours.", self.verbose)
     results = None
-    if len(self.dataset)>=2:
+    if len(self.dataset) >= 2:
       results = self.AnnAnnoy(options)
 
     if results < 0:

--- a/methods/flann/allknn.py
+++ b/methods/flann/allknn.py
@@ -56,14 +56,26 @@ class ALLKNN(object):
   def RunMetrics(self, options):
     Log.Info("Perform ALLKNN.", self.verbose)
 
+    # Parse options into string.
+    optionsStr = ""
+    if "k" in options:
+      optionsStr = "-k " + str(options.pop("k"))
+    if "seed" in options:
+      optionsStr = optionsStr + " -s " + str(options.pop("seed"))
+    if "epsilon" in options:
+      optionsStr = optionsStr + " -e " + str(options.pop("epsilon"))
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
     # If the dataset contains two files then the second file is the query file.
     # In this case we add this to the command line.
     if len(self.dataset) == 2:
       cmd = shlex.split(self.path + "allknn -r " + self.dataset[0] + " -q " +
-          self.dataset[1] + " -v " + options)
+          self.dataset[1] + " -v " + optionsStr)
     else:
       cmd = shlex.split(self.path + "allknn -r " + self.dataset +
-          " -v " + options)
+          " -v " + optionsStr)
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/hlearn/allknn.py
+++ b/methods/hlearn/allknn.py
@@ -66,14 +66,22 @@ class ALLKNN(object):
   def RunMetrics(self, options):
     Log.Info("Perform ALLKNN.", self.verbose)
 
+    # This is not tested since HLearn has not worked in the current benchmarking
+    # setup, but, if you are trying to get it to work, this *should* work...
+    optionsStr = ""
+    if "k" in options:
+      optionsStr = "-k " + str(options["k"])
+    if "seed" in options:
+      optionsStr = optionsStr + " -s " + str(options["seed"])
+
     # If the dataset contains two files then the second file is the query file.
     # In this case we add this to the command line.
     if len(self.dataset) == 2:
       cmd = shlex.split(self.path + "hlearn-allknn -r " + self.dataset[0] + " -q " +
-          self.dataset[1] + " " + options)
+          self.dataset[1] + " " + optionsStr)
     else:
       cmd = shlex.split(self.path + "hlearn-allknn -r " + self.dataset +
-          " " + options)
+          " " + optionsStr)
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/matlab/allknn.py
+++ b/methods/matlab/allknn.py
@@ -55,12 +55,31 @@ class ALLKNN(object):
   def RunMetrics(self, options):
     Log.Info("Perform ALLKNN.", self.verbose)
 
+    # Convert options dict to string.
+    optionsStr = ""
+    if "k" in options:
+      optionsStr = "-k " + str(options.pop("k"))
+    else:
+      Log.Fatal("Number of neighbors to search for (k) required!")
+      raise Exception("missing option in YAML configuration")
+    if "seed" in options:
+      optionsStr = optionsStr + " -s " + str(options.pop("seed"))
+    if "naive_mode" in options:
+      optionsStr = optionsStr + " -N"
+      options.pop("naive_mode")
+    if "leaf_size" in options:
+      optionsStr = optionsStr + " -l " + str(options.pop("leaf_size"))
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
     # If the dataset contains two files then the second file is the query file.
     # In this case we add this to the command line.
     if len(self.dataset) == 2:
-      inputCmd = "-r " + self.dataset[0] + " -q " + self.dataset[1] + " " + options
+      inputCmd = "-r " + self.dataset[0] + " -q " + self.dataset[1] + " " \
+          + optionsStr
     else:
-      inputCmd = "-r " + self.dataset + " " + options
+      inputCmd = "-r " + self.dataset + " " + optionsStr
 
     # Split the command using shell-like syntax.
     cmd = shlex.split(self.path + "matlab -nodisplay -nosplash -r \"try, " +

--- a/methods/matlab/hmm_generate.py
+++ b/methods/matlab/hmm_generate.py
@@ -103,7 +103,16 @@ class HMMGENERATE(object):
     if (self.error == -1):
       return -1
 
-    inputCmd = "-e emis_tmp.csv -t trans_tmp.csv " + options
+    if not "length" in options:
+      Log.Fatal("'length' parameter required for HMM generate task!")
+      raise Exception("missing option in configuration")
+
+    optionsStr = "-l " + str(options.pop("length"))
+    if len(options) > 1:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
+    inputCmd = "-e emis_tmp.csv -t trans_tmp.csv " + optionsStr
     # Split the command using shell-like syntax.
     cmd = shlex.split(self.path + "matlab -nodisplay -nosplash -r \"try, " +
       "HMM_GENERATE('"  + inputCmd + "'), catch, exit(1), end, exit(0)\"")

--- a/methods/matlab/hmm_viterbi.py
+++ b/methods/matlab/hmm_viterbi.py
@@ -104,7 +104,12 @@ class HMMVITERBI(object):
   def RunMetrics(self, options):
     Log.Info("Perform HMM VITERBI.", self.verbose)
 
-    inputCmd = "-i " + self.dataset[0] + " -e emis_tmp.csv -t trans_tmp.csv " + options
+    # No options accepted for this task.
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
+    inputCmd = "-i " + self.dataset[0] + " -e emis_tmp.csv -t trans_tmp.csv "
     # Split the command using shell-like syntax.
     cmd = shlex.split(self.path + "matlab -nodisplay -nosplash -r \"try, " +
       "HMM_VITERBI('"  + inputCmd + "'), catch, exit(1), end, exit(0)\"")

--- a/methods/matlab/kmeans.py
+++ b/methods/matlab/kmeans.py
@@ -55,12 +55,30 @@ class KMEANS(object):
   def RunMetrics(self, options):
     Log.Info("Perform K-Means.", self.verbose)
 
+    # Parse options into string.
+    optionsStr = ""
+    if "clusters" in options:
+      optionsStr = "-c " + str(options.pop("clusters"))
+    else:
+      Log.Fatal("Required parameter 'clusters' not specified in configuration!")
+      raise Exception("missing parameter")
+
+    if "seed" in options:
+      optionsStr = optionsStr + " -s " + str(options.pop("seed"))
+    if "max_iterations" in options:
+      optionsStr = optionsStr + " -m " + str(options.pop("max_iterations"))
+
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
     # If the dataset contains two files then the second file is the centroids
     # file. In this case we add this to the command line.
     if len(self.dataset) == 2:
-      inputCmd = "-i " + self.dataset[0] + " -I " + self.dataset[1] + " " + options
+      inputCmd = "-i " + self.dataset[0] + " -I " + self.dataset[1] + " "
+          + optionsStr
     else:
-      inputCmd = "-i " + self.dataset[0] + " " + options
+      inputCmd = "-i " + self.dataset[0] + " " + optionsStr
 
     # Split the command using shell-like syntax.
     cmd = shlex.split(self.path + "matlab -nodisplay -nosplash -r \"try, " +

--- a/methods/matlab/kmeans.py
+++ b/methods/matlab/kmeans.py
@@ -75,7 +75,7 @@ class KMEANS(object):
     # If the dataset contains two files then the second file is the centroids
     # file. In this case we add this to the command line.
     if len(self.dataset) == 2:
-      inputCmd = "-i " + self.dataset[0] + " -I " + self.dataset[1] + " "
+      inputCmd = "-i " + self.dataset[0] + " -I " + self.dataset[1] + " " \
           + optionsStr
     else:
       inputCmd = "-i " + self.dataset[0] + " " + optionsStr

--- a/methods/matlab/linear_regression.py
+++ b/methods/matlab/linear_regression.py
@@ -64,19 +64,23 @@ class LinearRegression(object):
   Linear Regression benchmark instance. If the method has been successfully
   completed return the elapsed time in seconds.
 
-  @param options - Extra options for the method.
+  @param options - Extra options for the method (none accepted).
   @return - Elapsed time in seconds or a negative value if the method was not
   successful.
   '''
   def RunMetrics(self, options):
     Log.Info("Perform Linear Regression.", self.verbose)
 
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
     # If the dataset contains two files then the second file is the test
     # file. In this case we add this to the command line.
     if len(self.dataset) == 2:
-      inputCmd = "-i " + self.dataset[0] + " -t " + self.dataset[1] + " " + options
+      inputCmd = "-i " + self.dataset[0] + " -t " + self.dataset[1]
     else:
-      inputCmd = "-i " + self.dataset[0] + " " + options
+      inputCmd = "-i " + self.dataset[0] + " "
 
     print(self.path + "matlab -nodisplay -nosplash -r \"try, " +
         "LINEAR_REGRESSION('"  + inputCmd + "'), catch, exit(1), end, exit(0)\"")

--- a/methods/matlab/logistic_regression.py
+++ b/methods/matlab/logistic_regression.py
@@ -72,12 +72,17 @@ class LogisticRegression(object):
   def RunMetrics(self, options):
     Log.Info("Perform Logistic Regression.", self.verbose)
 
+    # No options accepted for this script.
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
     # If the dataset contains two files then the second file is the test
     # file. In this case we add this to the command line.
     if len(self.dataset) == 2:
-      inputCmd = "-i " + self.dataset[0] + " -t " + self.dataset[1] + " " + options
+      inputCmd = "-i " + self.dataset[0] + " -t " + self.dataset[1]
     else:
-      inputCmd = "-i " + self.dataset[0] + " " + options
+      inputCmd = "-i " + self.dataset[0]
 
     # Split the command using shell-like syntax.
     cmd = shlex.split(self.path + "matlab -nodisplay -nosplash -r \"try, " +

--- a/methods/matlab/nbc.py
+++ b/methods/matlab/nbc.py
@@ -78,7 +78,7 @@ class NBC(object):
       Log.Fatal("Unknown parameters: " + str(options))
       raise Exception("unknown parameters")
 
-    inputCmd = "-t " + self.dataset[0] + " -T " + self.dataset[1] + " " + options
+    inputCmd = "-t " + self.dataset[0] + " -T " + self.dataset[1] 
     # Split the command using shell-like syntax.
     cmd = shlex.split(self.path + "matlab -nodisplay -nosplash -r \"try, NBC('"
         + inputCmd + "'), catch, exit(1), end, exit(0)\"")

--- a/methods/matlab/nbc.py
+++ b/methods/matlab/nbc.py
@@ -73,6 +73,11 @@ class NBC(object):
   def RunMetrics(self, options):
     Log.Info("Perform NBC.", self.verbose)
 
+    # No options accepted for this task.
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
     inputCmd = "-t " + self.dataset[0] + " -T " + self.dataset[1] + " " + options
     # Split the command using shell-like syntax.
     cmd = shlex.split(self.path + "matlab -nodisplay -nosplash -r \"try, NBC('"

--- a/methods/matlab/nmf.py
+++ b/methods/matlab/nmf.py
@@ -55,7 +55,26 @@ class NMF(object):
   def RunMetrics(self, options):
     Log.Info("Perform NMF.", self.verbose)
 
-    inputCmd = "-i " + self.dataset + " " + options
+    # Parse options into string.
+    optionsStr = ""
+    if "rank" in options:
+      optionsStr = "-r " + str(options.pop("rank"))
+    else:
+      Log.Fatal("Parameter 'rank' required but not specified!")
+      raise Exception("missing parameter")
+
+    if "update_rules" in options:
+      optionsStr = optionsStr + " -u " + str(options.pop("update_rules"))
+    if "seed" in options:
+      optionsStr = optionsStr + " -s " + str(options.pop("seed"))
+    if "epsilon" in options:
+      optionsStr = optionsStr + " -e " + str(options.pop("epsilon"))
+
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
+    inputCmd = "-i " + self.dataset + " " + optionsStr
     # Split the command using shell-like syntax.
     cmd = shlex.split(self.path + "matlab -nodisplay -nosplash -r \"try, NMF('"
         + inputCmd + "'), catch, exit(1), end, exit(0)\"")

--- a/methods/matlab/pca.py
+++ b/methods/matlab/pca.py
@@ -55,7 +55,18 @@ class PCA(object):
   def RunMetrics(self, options):
     Log.Info("Perform PCA.", self.verbose)
 
-    inputCmd = "-i " + self.dataset + " " + options
+    # Parse options into string.
+    optionsStr = ""
+    if "new_dimensionality" in options:
+      optionsStr = "-d " + str(options.pop("new_dimensionality"))
+    if "scaling" in options:
+      optionsStr = optionsStr + " -s"
+      options.pop("scaling")
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
+    inputCmd = "-i " + self.dataset + " " + optionsStr
     # Split the command using shell-like syntax.
     cmd = shlex.split(self.path + "matlab -nodisplay -nosplash -r \"try, PCA('"
         + inputCmd + "'), catch, exit(1), end, exit(0)\"")

--- a/methods/matlab/perceptron.py
+++ b/methods/matlab/perceptron.py
@@ -73,12 +73,21 @@ class PERCEPTRON(object):
   def RunMetrics(self, options):
     Log.Info("Perform Perceptron prediction.", self.verbose)
 
+    # Parse options into string.
+    optionsStr = ""
+    if "max_iterations" in options:
+      optionsStr = "-n " + str(options.pop("max_iterations"))
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
     # If the dataset contains two files then the second file is the test
     # file. In this case we add this to the command line.
     if len(self.dataset) >= 2:
-      inputCmd = "-t " + self.dataset[0] + " -T " + self.dataset[1] + " " + options
+      inputCmd = "-t " + self.dataset[0] + " -T " + self.dataset[1] + " " \
+          + optionsStr
     else:
-      inputCmd = "-t " + self.dataset + " " + options
+      inputCmd = "-t " + self.dataset + " " + optionsStr
 
     # Split the command using shell-like syntax.
     cmd = shlex.split(self.path + "matlab -nodisplay -nosplash -r \"try, " +

--- a/methods/matlab/range_search.py
+++ b/methods/matlab/range_search.py
@@ -55,12 +55,31 @@ class RANGESEARCH(object):
   def RunMetrics(self, options):
     Log.Info("Perform Range Search.", self.verbose)
 
+    # Parse options into string.
+    optionsStr = ""
+    if "max" in options:
+      optionsStr = "-M " + str(options.pop("max"))
+    else:
+      Log.Fatal("Parameter 'max' is required!")
+      raise Exception("missing parameter")
+
+    if "leaf_size" in options:
+      optionsStr = optionsStr + " -l " + str(options.pop("leaf_size"))
+    if "naive_mode" in options:
+      optionsStr = optionsStr + " -N"
+      options.pop("naive_mode")
+
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
     # If the dataset contains two files then the second file is the query file.
     # In this case we add this to the command line.
     if len(self.dataset) == 2:
-      inputCmd = "-r " + self.dataset[0] + " -q " + self.dataset[1] + " " + options
+      inputCmd = "-r " + self.dataset[0] + " -q " + self.dataset[1] + " " \
+          + optionsStr
     else:
-      inputCmd = "-r " + self.dataset + " " + options
+      inputCmd = "-r " + self.dataset + " " + optionsStr
 
     # Split the command using shell-like syntax.
     cmd = shlex.split(self.path + "matlab -nodisplay -nosplash -r \"try, " +

--- a/methods/metrics/definitions.py
+++ b/methods/metrics/definitions.py
@@ -49,16 +49,16 @@ class Metrics(object):
   '''
   @staticmethod
   def AverageAccuracy(CM):
-    acc=0
+    acc=0.0
     Sum=0
     l=len(CM)
     for i in range(l):
         for j in range(l):
             Sum+=CM[i][j]
-        acc = acc + (CM[i][i]/Sum)*100
+        acc = acc + (float(CM[i][i])/float(Sum))*100.0
         Sum=0
     acc = acc/l
-    return acc/100
+    return acc/100.0
 
 
   '''

--- a/methods/metrics/definitions.py
+++ b/methods/metrics/definitions.py
@@ -137,6 +137,7 @@ class Metrics(object):
   '''
   @staticmethod
   def FMeasureClass(class_i,CM):
+    l = len(CM)
     precClass = Metrics.PrecisionForAClass(class_i,CM)
     recClass = Metrics.RecallForAClass(class_i,CM)
     if (precClass + recClass) != 0:

--- a/methods/milk/adaboost.py
+++ b/methods/milk/adaboost.py
@@ -2,7 +2,6 @@
   @file adaboost.py
   AdaBoost classifier with Milk.
 '''
-
 import os
 import sys
 import inspect
@@ -99,6 +98,11 @@ class ADABOOST(object):
   '''
   def RunMetrics(self, options):
     Log.Info("Perform ADABOOST.", self.verbose)
+
+    # No extra options allowed.
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
 
     results = None
     if len(self.dataset) >= 2:

--- a/methods/milk/dtc.py
+++ b/methods/milk/dtc.py
@@ -44,7 +44,7 @@ class DTC(object):
     self.dataset = dataset
     self.timeout = timeout
     self.model = None
-    self.min_split = 4
+    self.min_split = -1
   '''
   Build the model for the Decision Tree Classifier.
   @param data - The train data.
@@ -53,7 +53,10 @@ class DTC(object):
   '''
   def BuildModel(self):
     # Create and train the classifier.
-    dtc_learner = tree_learner(min_split = self.min_split)
+    if min_split != -1:
+      dtc_learner = tree_learner(min_split=self.min_split)
+    else:
+      dtc_learner = tree_learner()
     return dtc_learner
 
   '''
@@ -69,9 +72,13 @@ class DTC(object):
       Log.Info("Loading dataset", self.verbose)
       trainData, labels = SplitTrainData(self.dataset)
       testData = LoadDataset(self.dataset[1])
-      
-      min_split = re.search("--minimum_leaf_size (\d+)", options)
-      self.min_split = 4 if not min_split else int(min_split.group(1))
+
+      # Parse options.
+      if "minimum_leaf_size" in options:
+        self.min_split = options.pop("minimum_leaf_size")
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
 
       try:
         self.model = self.BuildModel()

--- a/methods/milk/dtc.py
+++ b/methods/milk/dtc.py
@@ -53,7 +53,7 @@ class DTC(object):
   '''
   def BuildModel(self):
     # Create and train the classifier.
-    if min_split != -1:
+    if self.min_split != -1:
       dtc_learner = tree_learner(min_split=self.min_split)
     else:
       dtc_learner = tree_learner()

--- a/methods/milk/kmeans.py
+++ b/methods/milk/kmeans.py
@@ -58,8 +58,13 @@ class KMEANS(object):
         data = np.genfromtxt(self.dataset, delimiter=',')
 
       # Gather parameters.
-      clusters = re.search("-c (\d+)", options)
-      maxIterations = re.search("-m (\d+)", options)
+      if "clusters" in options:
+        clusters = options.pop("clusters")
+      if "max_iterations" in options:
+        maxIterations = options.pop("max_iterations")
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
 
       # Now do validation of options.
       if not clusters and len(self.dataset) != 2:
@@ -72,7 +77,7 @@ class KMEANS(object):
         q.put(-1)
         return -1
 
-      m = 1000 if not maxIterations else int(maxIterations.group(1))
+      m = 1000 if not maxIterations else int(maxIterations)
 
       try:
         # Create the KMeans object and perform K-Means clustering.
@@ -85,7 +90,7 @@ class KMEANS(object):
                                  return_centroids=False)
           else:
             assignments, centroids = kmeans(data,
-                                            int(clusters.group(1)),
+                                            int(clusters),
                                             max_iter=m)
 
       except Exception as e:

--- a/methods/milk/kmeans.py
+++ b/methods/milk/kmeans.py
@@ -58,8 +58,10 @@ class KMEANS(object):
         data = np.genfromtxt(self.dataset, delimiter=',')
 
       # Gather parameters.
+      clusters = None
       if "clusters" in options:
         clusters = options.pop("clusters")
+      maxIterations = None
       if "max_iterations" in options:
         maxIterations = options.pop("max_iterations")
       if len(options) > 0:
@@ -71,7 +73,7 @@ class KMEANS(object):
         Log.Fatal("Required option: Number of clusters or cluster locations.")
         q.put(-1)
         return -1
-      elif (not clusters or int(clusters.group(1)) < 1) and len(self.dataset) != 2:
+      elif (not clusters or int(clusters) < 1) and len(self.dataset) != 2:
         Log.Fatal("Invalid number of clusters requested! Must be greater than"
             + " or equal to 1.")
         q.put(-1)
@@ -84,7 +86,7 @@ class KMEANS(object):
         with totalTimer:
           if len(self.dataset) == 2:
             assignments = kmeans(data,
-                                 int(clusters.group(1)),
+                                 int(clusters),
                                  max_iter=m,
                                  centroids=centroids,
                                  return_centroids=False)
@@ -94,6 +96,7 @@ class KMEANS(object):
                                             max_iter=m)
 
       except Exception as e:
+        Log.Fatal("Exception: " + str(e))
         q.put(-1)
         return -1
 

--- a/methods/milk/logistic_regression.py
+++ b/methods/milk/logistic_regression.py
@@ -69,6 +69,11 @@ class LogisticRegression(object):
       trainData, labels = SplitTrainData(self.dataset)
       testData = LoadDataset(self.dataset[1])
 
+      # No options allowed.
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
+
       try:
         self.model = self.BuildModel()
         with totalTimer:

--- a/methods/milk/random_forest.py
+++ b/methods/milk/random_forest.py
@@ -71,6 +71,11 @@ class RANDOMFOREST(object):
       trainData, labels = SplitTrainData(self.dataset)
       testData = LoadDataset(self.dataset[1])
 
+      # TODO: must be able to specify number of trees in forest
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
+
       try:
         self.model = self.BuildModel()
         with totalTimer:

--- a/methods/milk/random_forest.py
+++ b/methods/milk/random_forest.py
@@ -45,6 +45,8 @@ class RANDOMFOREST(object):
     self.dataset = dataset
     self.timeout = timeout
     self.model = None
+    self.opts = {}
+
   '''
   Build the model for the Random Forest Classifier.
   @param data - The train data.
@@ -53,7 +55,7 @@ class RANDOMFOREST(object):
   '''
   def BuildModel(self):
     # Create and train the classifier.
-    rf_learner = randomforest.rf_learner()
+    rf_learner = randomforest.rf_learner(**self.opts)
     learner = one_against_one(rf_learner)
     return learner
 
@@ -71,7 +73,9 @@ class RANDOMFOREST(object):
       trainData, labels = SplitTrainData(self.dataset)
       testData = LoadDataset(self.dataset[1])
 
-      # TODO: must be able to specify number of trees in forest
+      if "num_trees" in options:
+        self.opts["rf"] = options.pop("num_trees")
+
       if len(options) > 0:
         Log.Fatal("Unknown parameters: " + str(options))
         raise Exception("unknown parameters")

--- a/methods/mlpack/allkfn.py
+++ b/methods/mlpack/allkfn.py
@@ -83,6 +83,32 @@ class ALLKFN(object):
         os.remove(f)
 
   '''
+  Convert a dict containing options into a string.
+  '''
+  def OptionsToStr(self, options):
+    optionsStr = ""
+    if "k" in options:
+      optionsStr = "-k " + str(options.pop("k"))
+    else:
+      Log.Fatal("Required parameter 'k' is missing!")
+      raise Exception("missing parameter")
+
+    if "single_mode" in options:
+      optionsStr = optionsStr + " --single_mode"
+      options.pop("single_mode")
+    if "naive_mode" in options:
+      optionsStr = optionsStr + " --naive"
+      options.pop("naive_mode")
+    if "leaf_size" in options:
+      optionsStr = optionsStr + " -l " + str(options.pop("leaf_size"))
+
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
+    return optionsStr
+
+  '''
   Run valgrind massif profiler on the All K-Furthest-Neighbors method. If
   the method has been successfully completed the report is saved in the
   specified file.
@@ -96,15 +122,17 @@ class ALLKFN(object):
   def RunMemory(self, options, fileName, massifOptions="--depth=2"):
     Log.Info("Perform ALLKFN Memory Profiling.", self.verbose)
 
+    optionsStr = self.OptionsToStr(options)
+
     # If the dataset contains two files then the second file is the query file.
     # In this case we add this to the command line.
     if len(self.dataset) == 2:
       cmd = shlex.split(self.debug + "mlpack_allkfn -r " + self.dataset[0] +
           " -q " + self.dataset[1] + " -v -n neighbors.csv -d distances.csv " +
-          options)
+          optionsStr)
     else:
       cmd = shlex.split(self.debug + "mlpack_allkfn -r " + self.dataset +
-          " -v -n neighbors.csv -d distances.csv " + options)
+          " -v -n neighbors.csv -d distances.csv " + optionsStr)
 
     return Profiler.MassifMemoryUsage(cmd, fileName, self.timeout, massifOptions)
 
@@ -118,15 +146,17 @@ class ALLKFN(object):
   def RunMetrics(self, options):
     Log.Info("Perform ALLKFN.", self.verbose)
 
+    optionsStr = self.OptionsToStr(options)
+
     # If the dataset contains two files then the second file is the query file.
     # In this case we add this to the command line.
     if len(self.dataset) == 2:
       cmd = shlex.split(self.path + "mlpack_allkfn -r " + self.dataset[0] +
           " -q " + self.dataset[1] + " -v -n neighbors.csv -d distances.csv " +
-          options)
+          optionsStr)
     else:
       cmd = shlex.split(self.path + "mlpack_allkfn -r " + self.dataset +
-          " -v -n neighbors.csv -d distances.csv " + options)
+          " -v -n neighbors.csv -d distances.csv " + optionsStr)
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/mlpack/allknn.py
+++ b/methods/mlpack/allknn.py
@@ -111,6 +111,8 @@ class ALLKNN(object):
       Log.Fatal("Unknown parameters: " + str(options))
       raise Exception("unknown parameters")
 
+    return optionsStr
+
   '''
   Run valgrind massif profiler on the All K-Nearest-Neighbors method. If
   the method has been successfully completed the report is saved in the

--- a/methods/mlpack/allknn.py
+++ b/methods/mlpack/allknn.py
@@ -82,6 +82,36 @@ class ALLKNN(object):
         os.remove(f)
 
   '''
+  Convert options dict into string.
+  '''
+  def OptionsToStr(self, options):
+    optionsStr = ""
+    if "k" in options:
+      optionsStr = "-k " + str(options.pop("k"))
+    else:
+      Log.Fatal("Required parameter 'k' not specified!")
+      raise Exception("missing parameter")
+
+    if "leaf_size" in options:
+      optionsStr = optionsStr + " -l " + str(options.pop("leaf_size"))
+    if "single_mode" in options:
+      optionsStr = optionsStr + " --single_mode"
+      options.pop("single_mode")
+    if "naive_mode" in options:
+      optionsStr = optionsStr + " --naive"
+      options.pop("naive_mode")
+    if "tree_type" in options:
+      optionsStr = optionsStr + " --tree_type " + str(options.pop("tree_type"))
+    if "epsilon" in options:
+      optionsStr = optionsStr + " --epsilon " + str(options.pop("epsilon"))
+    if "seed" in options:
+      optionsStr = optionsStr + " -s " + str(options.pop("seed"))
+
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
+  '''
   Run valgrind massif profiler on the All K-Nearest-Neighbors method. If
   the method has been successfully completed the report is saved in the
   specified file.
@@ -100,10 +130,10 @@ class ALLKNN(object):
     if len(self.dataset) == 2:
       cmd = shlex.split(self.debug + "mlpack_allknn -r " + self.dataset[0] +
           " -q " + self.dataset[1] + " -v -n neighbors.csv -d distances.csv " +
-          options)
+          self.OptionsToStr(options))
     else:
       cmd = shlex.split(self.debug + "mlpack_allknn -r " + self.dataset +
-          " -v -n neighbors.csv -d distances.csv " + options)
+          " -v -n neighbors.csv -d distances.csv " + self.OptionsToStr(options))
 
     return Profiler.MassifMemoryUsage(cmd, fileName, self.timeout, massifOptions)
 
@@ -122,10 +152,10 @@ class ALLKNN(object):
     if len(self.dataset) == 2:
       cmd = shlex.split(self.path + "mlpack_allknn -r " + self.dataset[0] +
           " -q " + self.dataset[1] + " -v -n neighbors.csv -d distances.csv " +
-          options)
+          self.OptionsToStr(options))
     else:
       cmd = shlex.split(self.path + "mlpack_allknn -r " + self.dataset +
-          " -v -n neighbors.csv -d distances.csv " + options)
+          " -v -n neighbors.csv -d distances.csv " + self.OptionsToStr(options))
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/mlpack/allkrann.py
+++ b/methods/mlpack/allkrann.py
@@ -84,7 +84,7 @@ class ALLKRANN(object):
   '''
   Convert options dict to string usable by programs.
   '''
-  def OptionsToStr(self):
+  def OptionsToStr(self, options):
     optionsStr = ""
     if "k" in options:
       optionsStr = "-k " + str(options.pop("k"))
@@ -110,6 +110,8 @@ class ALLKRANN(object):
     if len(options) > 0:
       Log.Fatal("Unknown parameters: " + str(options))
       raise Exception("unknown parameters")
+
+    return optionsStr
 
   '''
   Run valgrind massif profiler on the All K-Rank-Approximate-Nearest-Neighbors

--- a/methods/mlpack/allkrann.py
+++ b/methods/mlpack/allkrann.py
@@ -82,6 +82,36 @@ class ALLKRANN(object):
         os.remove(f)
 
   '''
+  Convert options dict to string usable by programs.
+  '''
+  def OptionsToStr(self):
+    optionsStr = ""
+    if "k" in options:
+      optionsStr = "-k " + str(options.pop("k"))
+    else:
+      Log.Fatal("Required parameter 'k' not specified!")
+      raise Exception("missing parameter")
+
+    if "tau" in options:
+      optionsStr = optionsStr + " -T " + str(options.pop("tau"))
+    if "naive_mode" in options:
+      optionsStr = optionsStr + " --naive"
+      options.pop("naive_mode")
+    if "single_mode" in options:
+      optionsStr = optionsStr + " --single_mode"
+      options.pop("single_mode")
+    if "sample_at_leaves" in options:
+      optionsStr = optionsStr + " -L"
+      options.pop("sample_at_leaves")
+    if "first_leaf_exact" in options:
+      optionsStr = optionsStr + " -X"
+      options.pop("first_leaf_exact")
+
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
+  '''
   Run valgrind massif profiler on the All K-Rank-Approximate-Nearest-Neighbors
   method. If the method has been successfully completed the report is saved in
   the specified file.
@@ -100,10 +130,10 @@ class ALLKRANN(object):
     if len(self.dataset) == 2:
       cmd = shlex.split(self.debug + "mlpack_allkrann -r " + self.dataset[0] +
           " -q " + self.dataset[1] + " -v -n neighbors.csv -d distances.csv " +
-          options)
+          self.OptionsToStr(options))
     else:
       cmd = shlex.split(self.debug + "mlpack_allkrann -r " + self.dataset +
-          " -v -n neighbors.csv -d distances.csv " + options)
+          " -v -n neighbors.csv -d distances.csv " + self.OptionsToStr(options))
 
     return Profiler.MassifMemoryUsage(cmd, fileName, self.timeout, massifOptions)
 
@@ -122,10 +152,10 @@ class ALLKRANN(object):
     if len(self.dataset) == 2:
       cmd = shlex.split(self.path + "mlpack_allkrann -r " + self.dataset[0] +
           " -q " + self.dataset[1] + " -v -n neighbors.csv -d distances.csv " +
-          options)
+          self.OptionsToStr(options))
     else:
       cmd = shlex.split(self.path + "mlpack_allkrann -r " + self.dataset +
-          " -v -n neighbors.csv -d distances.csv " + options)
+          " -v -n neighbors.csv -d distances.csv " + self.OptionsToStr(options))
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/mlpack/decision_stump.py
+++ b/methods/mlpack/decision_stump.py
@@ -103,11 +103,15 @@ class DecisionStump(object):
   def RunMemory(self, options, fileName, massifOptions="--depth=2"):
     Log.Info("Perform Memory Profiling.", self.verbose)
 
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
     # If the dataset contains two files then the second file is the test file.
     # In this case we add this to the command line.
     if len(self.dataset) >= 2:
       cmd = shlex.split(self.debug + "mlpack_decision_stump -t " +
-          self.dataset[0] + " -T " + self.dataset[1] + " -v " + options)
+          self.dataset[0] + " -T " + self.dataset[1] + " -v")
     else:
       Log.Fatal("This method requires atleast two datasets.")
 
@@ -124,11 +128,15 @@ class DecisionStump(object):
   def RunMetrics(self, options):
     Log.Info("Perform Decision Stump Prediction.", self.verbose)
 
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
     # If the dataset contains two files then the second file is the labels file.
     # In this case we add this to the command line.
     if len(self.dataset) >= 2:
       cmd = shlex.split(self.path + "mlpack_decision_stump -t " +
-          self.dataset[0] + " -T " + self.dataset[1] + " -v " + options)
+          self.dataset[0] + " -T " + self.dataset[1] + " -v")
     else:
       Log.Fatal("This method requires atleast two datasets.")
 

--- a/methods/mlpack/det.py
+++ b/methods/mlpack/det.py
@@ -84,6 +84,19 @@ class DET(object):
         os.remove(f)
 
   '''
+  Convert an options dict to a string that can be passed to the program.
+  '''
+  def OptionsToStr(self, options):
+    optionsStr = ""
+    if "folds" in options:
+      optionsStr = "-f " + str(options.pop("folds"))
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
+    return optionsStr
+
+  '''
   Run valgrind massif profiler on the Density Estimation method. If the method
   has been successfully completed the report is saved in the specified file.
 
@@ -100,10 +113,10 @@ class DET(object):
     # In this case we add this to the command line.
     if len(self.dataset) == 2:
       cmd = shlex.split(self.debug + "mlpack_det -t " + self.dataset[0] +
-          " -T " + self.dataset[1] + " -v " + options)
+          " -T " + self.dataset[1] + " -v " + self.OptionsToStr(options))
     else:
       cmd = shlex.split(self.debug + "mlpack_det -t " + self.dataset + " -v " +
-          options)
+          self.OptionsToStr(options))
 
     return Profiler.MassifMemoryUsage(cmd, fileName, self.timeout, massifOptions)
 
@@ -122,10 +135,10 @@ class DET(object):
     # In this case we add this to the command line.
     if len(self.dataset) == 2:
       cmd = shlex.split(self.path + "mlpack_det -t " + self.dataset[0] +
-          " -T " + self.dataset[1] + " -v " + options)
+          " -T " + self.dataset[1] + " -v " + self.OptionsToStr(options))
     else:
       cmd = shlex.split(self.path + "mlpack_det -t " + self.dataset + " -v " +
-          options)
+          self.OptionsToStr(options))
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/mlpack/emst.py
+++ b/methods/mlpack/emst.py
@@ -82,6 +82,20 @@ class EMST(object):
         os.remove(f)
 
   '''
+  Convert an options dict to a string that can be passed to the program.
+  '''
+  def OptionsToStr(self, options):
+    optionsStr = ""
+    if "naive_mode" in options:
+      optionsStr = "-N"
+      options.pop("naive_mode")
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
+    return optionsStr
+
+  '''
   Run valgrind massif profiler on the Fast Euclidean Minimum Spanning Tree
   method. If the method has been successfully completed the report is saved in
   the specified file.
@@ -96,7 +110,7 @@ class EMST(object):
     Log.Info("Perform EMST Memory Profiling.", self.verbose)
 
     cmd = shlex.split(self.debug + "mlpack_emst -i " + self.dataset + " -v " +
-      options)
+      self.OptionsToStr(options))
 
     return Profiler.MassifMemoryUsage(cmd, fileName, self.timeout, massifOptions)
 
@@ -112,7 +126,7 @@ class EMST(object):
     Log.Info("Perform EMST.", self.verbose)
 
     cmd = shlex.split(self.path + "mlpack_emst -i " + self.dataset + " -v " +
-      options)
+      self.OptionsToStr(options))
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/mlpack/fastmks.py
+++ b/methods/mlpack/fastmks.py
@@ -82,6 +82,35 @@ class FastMKS(object):
         os.remove(f)
 
   '''
+  Convert an options dict to a string that can be passed to the program.
+  '''
+  def OptionsToStr(self, options):
+    optionsStr = ""
+    if "k" in options:
+      optionsStr = "-k " + str(options.pop("k"))
+    else:
+      Log.Fatal("Required parameter 'k' is missing!")
+      raise Exception("missing parameter")
+
+    if "kernel" in options:
+      optionsStr = optionsStr + " -K " + str(options.pop("kernel"))
+    else:
+      Log.Fatal("Required parameter 'kernel' is missing!")
+      raise Exception("missing parameter")
+
+    if "degree" in options:
+      optionsStr = optionsStr + " -d " + str(options.pop("degree"))
+    if "single_mode" in options:
+      optionsStr = optionsStr + " --single_mode"
+      options.pop("single_mode")
+
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
+    return optionsStr
+
+  '''
   Run valgrind massif profiler on the Fast Max-Kernel Search method. If the
   method has been successfully completed the report is saved in the specified
   file.
@@ -99,10 +128,10 @@ class FastMKS(object):
     # In this case we add this to the command line.
     if len(self.dataset) == 2:
       cmd = shlex.split(self.debug + "mlpack_fastmks -r " + self.dataset[0] +
-          " -q " + self.dataset[1] + " -v " + options)
+          " -q " + self.dataset[1] + " -v " + self.OptionsToStr(options))
     else:
       cmd = shlex.split(self.debug + "mlpack_fastmks -r " + self.dataset +
-          " -v " + options)
+          " -v " + self.OptionsToStr(options))
 
     return Profiler.MassifMemoryUsage(cmd, fileName, self.timeout, massifOptions)
 
@@ -121,10 +150,10 @@ class FastMKS(object):
     # In this case we add this to the command line.
     if len(self.dataset) == 2:
       cmd = shlex.split(self.path + "mlpack_fastmks -r " + self.dataset[0] +
-          " -q " + self.dataset[1] + " -v " + options)
+          " -q " + self.dataset[1] + " -v " + self.OptionsToStr(options))
     else:
       cmd = shlex.split(self.path + "mlpack_fastmks -r " + self.dataset +
-          " -v " + options)
+          " -v " + self.OptionsToStr(options))
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/mlpack/hmm_generate.py
+++ b/methods/mlpack/hmm_generate.py
@@ -82,6 +82,20 @@ class HMMGENERATE(object):
         os.remove(f)
 
   '''
+  Given an options dict, return a string that can be passed to the program.
+  '''
+  def OptionsToStr(self, options):
+    optionsStr = ""
+    if "length" in options:
+      optionsStr = "-l " + str(options.pop("length"))
+
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
+    return optionsStr
+
+  '''
   Run valgrind massif profiler on the Hidden Markov Model Sequence Generator
   method. If the method has been successfully completed the report is saved in
   the specified file.
@@ -96,7 +110,7 @@ class HMMGENERATE(object):
     Log.Info("Perform HMM Generate Memory Profiling.", self.verbose)
 
     cmd = shlex.split(self.debug + "mlpack_hmm_generate -m " + self.dataset +
-        " -v  " + options)
+        " -v  " + self.OptionsToStr(options))
 
     return Profiler.MassifMemoryUsage(cmd, fileName, self.timeout, massifOptions)
 
@@ -112,7 +126,7 @@ class HMMGENERATE(object):
     Log.Info("Perform HMM Generate.", self.verbose)
 
     cmd = shlex.split(self.path + "mlpack_hmm_generate -m " + self.dataset +
-        " -v  " + options)
+        " -v  " + self.OptionsToStr(options))
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/mlpack/hmm_loglik.py
+++ b/methods/mlpack/hmm_loglik.py
@@ -96,9 +96,13 @@ class HMMLOGLIK(object):
   def RunMemory(self, options, fileName, massifOptions="--depth=2"):
     Log.Info("Perform HMM LOGLIK Memory Profiling.", self.verbose)
 
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
     if len(self.dataset) == 2:
       cmd = shlex.split(self.debug + "mlpack_hmm_loglik -i " + self.dataset[0] +
-          " -m " + self.dataset[1] + " -v " + options)
+          " -m " + self.dataset[1] + " -v")
     else:
       Log.Fatal("This method requires two datasets.")
       return -1
@@ -116,9 +120,13 @@ class HMMLOGLIK(object):
   def RunMetrics(self, options):
     Log.Info("Perform Markov Model Sequence Log-Likelihood.", self.verbose)
 
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
     if len(self.dataset) == 2:
       cmd = shlex.split(self.path + "mlpack_hmm_loglik -i " + self.dataset[0] +
-          " -m " + self.dataset[1] + " -v " + options)
+          " -m " + self.dataset[1] + " -v")
     else:
       Log.Fatal("This method requires two datasets.")
       return -1

--- a/methods/mlpack/hmm_train.py
+++ b/methods/mlpack/hmm_train.py
@@ -82,6 +82,28 @@ class HMMTRAIN(object):
         os.remove(f)
 
   '''
+  Convert an options dict to a string that can be passed to the program.
+  '''
+  def OptionsToStr(self, options):
+    optionsStr = ""
+    if "type" in options:
+      optionsStr = "-t " + str(options.pop("type"))
+    else:
+      Log.Fatal("Required parameter 'type' not specified!")
+      raise Exception("missing parameter")
+
+    if "states" in options:
+      optionsStr = optionsStr + " -n " + str(options.pop("states"))
+    if "seed" in options:
+      optionsStr = optionsStr + " --seed " + str(options.pop("seed"))
+
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Execption("unknown parameters")
+
+    return optionsStr
+
+  '''
   Run valgrind massif profiler on the Hidden Markov Model Training method. If
   the method has been successfully completed the report is saved in the
   specified file.
@@ -99,10 +121,10 @@ class HMMTRAIN(object):
     # In this case we add this to the command line.
     if len(self.dataset) == 2:
       cmd = shlex.split(self.debug + "mlpack_hmm_train -i " + self.dataset[0] +
-          "-l " + self.dataset[1] + " -v " + options)
+          "-l " + self.dataset[1] + " -v " + self.OptionsToStr(options))
     else:
       cmd = shlex.split(self.debug + "mlpack_hmm_train -i " + self.dataset +
-          " -v  " + options)
+          " -v  " + self.OptionsToStr(options))
 
     return Profiler.MassifMemoryUsage(cmd, fileName, self.timeout, massifOptions)
 
@@ -121,10 +143,10 @@ class HMMTRAIN(object):
     # In this case we add this to the command line.
     if len(self.dataset) == 2:
       cmd = shlex.split(self.path + "mlpack_hmm_train -i " + self.dataset[0] +
-          "-l " + self.dataset[1] + " -v " + options)
+          "-l " + self.dataset[1] + " -v " + self.OptionsToStr(options))
     else:
       cmd = shlex.split(self.path + "mlpack_hmm_train -i " + self.dataset +
-          " -v  " + options)
+          " -v  " + self.OptionsToStr(options))
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/mlpack/hmm_train.py
+++ b/methods/mlpack/hmm_train.py
@@ -96,6 +96,8 @@ class HMMTRAIN(object):
       optionsStr = optionsStr + " -n " + str(options.pop("states"))
     if "seed" in options:
       optionsStr = optionsStr + " --seed " + str(options.pop("seed"))
+    if "output" in options:
+      optionsStr = optionsStr + " -o " + str(options.pop("output"))
 
     if len(options) > 0:
       Log.Fatal("Unknown parameters: " + str(options))

--- a/methods/mlpack/hmm_viterbi.py
+++ b/methods/mlpack/hmm_viterbi.py
@@ -97,9 +97,13 @@ class HMMVITERBI(object):
   def RunMemory(self, options, fileName, massifOptions="--depth=2"):
     Log.Info("Perform HMM Viterbi Memory Profiling.", self.verbose)
 
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
     if len(self.dataset) >= 2:
       cmd = shlex.split(self.debug + "mlpack_hmm_viterbi -i " + self.dataset[0]
-          + " -m " + self.dataset[1] + " -v " + options)
+          + " -m " + self.dataset[1] + " -v")
     else:
       Log.Fatal("Not enough input datasets.")
       return -1
@@ -117,9 +121,13 @@ class HMMVITERBI(object):
   def RunMetrics(self, options):
     Log.Info("Perform HMM Viterbi State Prediction.", self.verbose)
 
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
     if len(self.dataset) >= 2:
       cmd = shlex.split(self.path + "mlpack_hmm_viterbi -i " + self.dataset[0] +
-          " -m " + self.dataset[1] + " -v " + options)
+          " -m " + self.dataset[1] + " -v")
     else:
       Log.Fatal("Not enough input datasets.")
       return -1

--- a/methods/mlpack/ica.py
+++ b/methods/mlpack/ica.py
@@ -95,9 +95,12 @@ class ICA(object):
   def RunMemory(self, options, fileName, massifOptions="--depth=2"):
     Log.Info("Perform ICA Memory Profiling.", self.verbose)
 
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
     # Split the command using shell-like syntax.
-    cmd = shlex.split(self.debug + "mlpack_radical -i " + self.dataset + " -v "
-        + options)
+    cmd = shlex.split(self.debug + "mlpack_radical -i " + self.dataset + " -v")
 
     return Profiler.MassifMemoryUsage(cmd, fileName, self.timeout, massifOptions)
 
@@ -112,9 +115,13 @@ class ICA(object):
   def RunMetrics(self, options):
     Log.Info("Perform ICA.", self.verbose)
 
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
     # Split the command using shell-like syntax.
-    cmd = shlex.split(self.path + "mlpack_radical -i " + self.dataset + " -v "
-        + options + " -o output_ic.csv -u output_unmixing.csv")
+    cmd = shlex.split(self.path + "mlpack_radical -i " + self.dataset + " -v"
+        + " -o output_ic.csv -u output_unmixing.csv")
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/mlpack/kernel_pca.py
+++ b/methods/mlpack/kernel_pca.py
@@ -82,6 +82,28 @@ class KPCA(object):
         os.remove(f)
 
   '''
+  Given an options dict, convert it to a string that can be used by the program.
+  '''
+  def OptionsToStr(self, options):
+    optionsStr = ""
+    if "kernel" in options:
+      optionsStr = "-k " + str(options.pop("kernel"))
+    else:
+      Log.Fatal("Required parameter 'kernel' not specified!")
+      raise Exception("missing parameter")
+    if "nystroem" in options:
+      optionsStr = optionsStr + " --nystroem_method"
+      options.pop("nystroem")
+    if "sampling_scheme" in options:
+      optionsStr = optionsStr + " -s " + str(options.pop("sampling_scheme"))
+
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
+    return optionsStr
+
+  '''
   Run valgrind massif profiler on the Kernel Principal Components Analysis
   method. If the method has been successfully completed the report is saved in
   the specified file.
@@ -97,7 +119,7 @@ class KPCA(object):
 
     # Split the command using shell-like syntax.
     cmd = shlex.split(self.debug + "mlpack_kernel_pca -i " + self.dataset +
-        " -v -o output.csv " + options)
+        " -v -o output.csv " + self.OptionsToStr(options))
 
     return Profiler.MassifMemoryUsage(cmd, fileName, self.timeout, massifOptions)
 
@@ -114,7 +136,7 @@ class KPCA(object):
 
     # Split the command using shell-like syntax.
     cmd = shlex.split(self.path + "mlpack_kernel_pca -i " + self.dataset +
-        " -v -o output.csv " + options)
+        " -v -o output.csv " + self.OptionsToStr(options))
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/mlpack/kmeans.py
+++ b/methods/mlpack/kmeans.py
@@ -82,6 +82,25 @@ class KMEANS(object):
         os.remove(f)
 
   '''
+  Convert an options dict to a string that can be passed to the program.
+  '''
+  def OptionsToStr(self, options):
+    optionsStr = ""
+    if "clusters" in options:
+      optionsStr = "-c " + str(options.pop("clusters"))
+    else:
+      Log.Fatal("Required parameter 'clusters' not specified!")
+      raise Exception("missing parameter")
+    if "max_iterations" in options:
+      optionsStr = optionsStr + " -m " + str(options.pop("max_iterations"))
+
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
+    return optionsStr
+
+  '''
   Run valgrind massif profiler on the K-Means clustering method. If the method
   has been successfully completed the report is saved in the specified file.
 
@@ -98,10 +117,11 @@ class KMEANS(object):
     # file.
     if len(self.dataset) == 2:
       cmd = shlex.split(self.debug + "mlpack_kmeans -i " + self.dataset[0] +
-          " -I " + self.dataset[1] + " -o output.csv -v " + options)
+          " -I " + self.dataset[1] + " -o output.csv -v " +
+          self.OptionsToStr(options))
     else:
       cmd = shlex.split(self.debug + "mlpack_kmeans -i " + self.dataset[0] +
-          " -o output.csv -v " + options)
+          " -o output.csv -v " + self.OptionsToStr(options))
 
     return Profiler.MassifMemoryUsage(cmd, fileName, self.timeout, massifOptions)
 
@@ -120,10 +140,11 @@ class KMEANS(object):
     # file.
     if len(self.dataset) == 2:
       cmd = shlex.split(self.path + "mlpack_kmeans -i " + self.dataset[0] +
-          " -I " + self.dataset[1] + " -o output.csv -v " + options)
+          " -I " + self.dataset[1] + " -o output.csv -v " +
+          self.OptionsToStr(options))
     else:
       cmd = shlex.split(self.path + "mlpack_kmeans -i " + self.dataset[0] +
-          " -o output.csv -v " + options)
+          " -o output.csv -v " + self.OptionsToStr(options))
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/mlpack/lars.py
+++ b/methods/mlpack/lars.py
@@ -82,6 +82,25 @@ class LARS(object):
         os.remove(f)
 
   '''
+  Given an options dict, convert to a string that can be passed to the program.
+  '''
+  def OptionsToStr(self, options):
+    optionsStr = ""
+    if "lambda1" in options:
+      optionsStr = "-l " + str(options.pop("lambda1"))
+    if "lambda2" in options:
+      optionsStr = optionsStr + " -L " + str(options.pop("lambda2"))
+    if "use_cholesky" in options:
+      optionsStr = optionsStr + " --use_cholesky"
+      options.pop("use_cholesky")
+
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
+    return optionsStr
+
+  '''
   Run valgrind massif profiler on the Least Angle Regression method. If the
   method has been successfully completed the report is saved in the specified
   file.
@@ -101,7 +120,7 @@ class LARS(object):
 
     # Split the command using shell-like syntax.
     cmd = shlex.split(self.debug + "mlpack_lars -i " + self.dataset[0] + " -r "
-        + self.dataset[1] + " -v " + options)
+        + self.dataset[1] + " -v " + self.OptionsToStr(options))
 
     return Profiler.MassifMemoryUsage(cmd, fileName, self.timeout, massifOptions)
 
@@ -122,7 +141,7 @@ class LARS(object):
 
     # Split the command using shell-like syntax.
     cmd = shlex.split(self.path + "mlpack_lars -i " + self.dataset[0] + " -r " +
-        self.dataset[1] + " -v " + options)
+        self.dataset[1] + " -v " + self.OptionsToStr(options))
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/mlpack/linear_regression.py
+++ b/methods/mlpack/linear_regression.py
@@ -102,14 +102,18 @@ class LinearRegression(object):
   def RunMemory(self, options, fileName, massifOptions="--depth=2"):
     Log.Info("Perform Local Coordinate Coding Memory Profiling.", self.verbose)
 
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
     # If the dataset contains two files then the second file is the test
     # regressors file. In this case we add this to the command line.
     if len(self.dataset) >= 2:
       cmd = shlex.split(self.debug + "mlpack_linear_regression -i " +
-          self.dataset[0] + " -t " + self.dataset[1] + " -v " + options)
+          self.dataset[0] + " -t " + self.dataset[1] + " -v")
     else:
       cmd = shlex.split(self.debug + "mlpack_linear_regression -i " +
-          self.dataset[0] + " -v " + options)
+          self.dataset[0] + " -v")
 
     return Profiler.MassifMemoryUsage(cmd, fileName, self.timeout, massifOptions)
 
@@ -124,14 +128,18 @@ class LinearRegression(object):
   def RunMetrics(self, options):
     Log.Info("Perform Simple Linear Regression.", self.verbose)
 
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
     # If the dataset contains two files then the second file is the test
     # regressors file. In this case we add this to the command line.
     if len(self.dataset) >= 2:
       cmd = shlex.split(self.path + "mlpack_linear_regression -t " +
-          self.dataset[0] + " -T " + self.dataset[1] + " -v " + options)
+          self.dataset[0] + " -T " + self.dataset[1] + " -v")
     else:
       cmd = shlex.split(self.path + "mlpack_linear_regression -t " +
-          self.dataset[0] + " -v " + options)
+          self.dataset[0] + " -v")
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/mlpack/local_coordinate_coding.py
+++ b/methods/mlpack/local_coordinate_coding.py
@@ -82,6 +82,30 @@ class LocalCoordinateCoding(object):
         os.remove(f)
 
   '''
+  Convert an input dict of options to an output string that can be passed to the
+  program.
+  '''
+  def OptionsToStr(self, options):
+    optionsStr = ""
+    if "atoms" in options:
+      optionsStr = "-k " + str(options.pop("atoms"))
+    else:
+      Log.Fatal("Required parameter 'atoms' not specified!")
+      raise Exception("missing parameter")
+
+    if "normalize" in options:
+      optionsStr = optionsStr + " -N"
+      options.pop("normalize")
+    if "seed" in options:
+      optionsStr = optionsStr + " --seed " + str(options.pop("seed"))
+
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
+    return optionsStr
+
+  '''
   Run valgrind massif profiler on the Local Coordinate Coding method. If the
   method has been successfully completed the report is saved in the specified
   file.
@@ -97,7 +121,7 @@ class LocalCoordinateCoding(object):
 
     # Split the command using shell-like syntax.
     cmd = shlex.split(self.debug + "mlpack_local_coordinate_coding -t " +
-        self.dataset + " -v " + options)
+        self.dataset + " -v " + self.OptionsToStr(options))
 
     return Profiler.MassifMemoryUsage(cmd, fileName, self.timeout, massifOptions)
 
@@ -113,7 +137,7 @@ class LocalCoordinateCoding(object):
     Log.Info("Perform Local Coordinate Coding.", self.verbose)
 
     cmd = shlex.split(self.path + "mlpack_local_coordinate_coding -t " +
-        self.dataset + " -v " + options)
+        self.dataset + " -v " + self.OptionsToStr(options))
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/mlpack/logistic_regression.py
+++ b/methods/mlpack/logistic_regression.py
@@ -90,6 +90,26 @@ class LogisticRegression(object):
         os.remove(f)
 
   '''
+  Convert an input dict of options to an output string that the program can use.
+  '''
+  def OptionsToStr(self, options):
+    optionsStr = ""
+    if "epsilon" in options:
+      optionsStr = "-e " + str(options.pop("epsilon"))
+    if "max_iterations" in options:
+      optionsStr = optionsStr + " -n " + str(options.pop("max_iterations"))
+    if "optimizer" in options:
+      optionsStr = optionsStr + " -O " + str(options.pop("optimizer"))
+    if "step_size" in options:
+      optionsStr = optionsStr + " -s " + str(options.pop("step_size"))
+
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
+    return optionsStr
+
+  '''
   Run valgrind massif profiler on the Logistic Regression Prediction
   method. If the method has been successfully completed the report is saved in
   the specified file.
@@ -107,10 +127,11 @@ class LogisticRegression(object):
     # regressors file. In this case we add this to the command line.
     if len(self.dataset) >= 2:
       cmd = shlex.split(self.debug + "mlpack_logistic_regression -i " +
-          self.dataset[0] + " -t " + self.dataset[1] + " -v " + options)
+          self.dataset[0] + " -t " + self.dataset[1] + " -v " +
+          self.OptionsToStr(options))
     else:
       cmd = shlex.split(self.debug + "mlpack_logistic_regression -i " +
-          self.dataset[0] + " -v " + options)
+          self.dataset[0] + " -v " + self.OptionsToStr(options))
 
     return Profiler.MassifMemoryUsage(cmd, fileName, self.timeout, massifOptions)
 
@@ -122,10 +143,11 @@ class LogisticRegression(object):
     # regressors file. In this case we add this to the command line.
     if len(self.dataset) >= 2:
       cmd = shlex.split(self.path + "mlpack_logistic_regression -t " +
-          self.dataset[0] + " -T " + self.dataset[1] + " -v " + options)
+          self.dataset[0] + " -T " + self.dataset[1] + " -v " +
+          self.OptionsToStr(options))
     else:
       cmd = shlex.split(self.path + "mlpack_logistic_regression -t " +
-          self.dataset + " -v " + options)
+          self.dataset + " -v " + self.OptionsToStr(options))
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/mlpack/lsh.py
+++ b/methods/mlpack/lsh.py
@@ -83,6 +83,27 @@ class LSH(object):
         os.remove(f)
 
   '''
+  Convert an input dict of options to an output string that can be used by the
+  program.
+  '''
+  def OptionsToStr(self, options):
+    optionsStr = ""
+    if "k" in options:
+      optionsStr = "-k " + str(options.pop("k"))
+    else:
+      Log.Fatal("Required parameter 'k' not specified!")
+      raise Exception("missing parameter")
+
+    if "seed" in options:
+      optionsStr = optionsStr + " -s " + str(options.pop("seed"))
+
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
+    return optionsStr
+
+  '''
   Run valgrind massif profiler on the All K-Approximate-Nearest-Neighbor method.
   If the method has been successfully completed the report is saved in the
   specified file.
@@ -98,7 +119,7 @@ class LSH(object):
 
     # Split the command using shell-like syntax.
     cmd = shlex.split(self.debug + "mlpack_lsh -r " + self.dataset + " -v " +
-        options)
+        self.OptionsToStr(options))
 
     return Profiler.MassifMemoryUsage(cmd, fileName, self.timeout, massifOptions)
 
@@ -115,7 +136,7 @@ class LSH(object):
 
     # Split the command using shell-like syntax.
     cmd = shlex.split(self.path + "mlpack_lsh -r " + self.dataset + " -v " +
-        options)
+        self.OptionsToStr(options))
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/mlpack/mlp_backward.py
+++ b/methods/mlpack/mlp_backward.py
@@ -72,6 +72,27 @@ class MLP_BACKWARD(object):
       self.description = description
 
   '''
+  Given an input dict of options, convert it to an output string that can be
+  used by the program.
+  '''
+  def OptionsToStr(self, options):
+    optionsStr = ""
+    if "input_size" in options:
+      optionsStr = "--input_size " + str(options.pop("input_size"))
+    if "hidden_size" in options:
+      optionsStr = optionsStr + " --hidden_size " +
+          str(options.pop("hidden_size"))
+    if "output_size" in options:
+      optionsStr = optionsStr + " --output_size " +
+          str(options.pop("output_size"))
+
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters:" + str(options))
+      raise Exception("unknown parameters")
+
+    return optionsStr
+
+  '''
   Perform the linear backward pass. If the method has been successfully
   completed return the elapsed time in seconds.
 
@@ -83,7 +104,8 @@ class MLP_BACKWARD(object):
     Log.Info("Perform MLP Backward.", self.verbose)
 
     # Split the command using shell-like syntax.
-    cmd = shlex.split(self.path + "mlp_backward -v " + options)
+    cmd = shlex.split(self.path + "mlp_backward -v " +
+        self.OptionsToStr(options))
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/mlpack/mlp_forward.py
+++ b/methods/mlpack/mlp_forward.py
@@ -72,6 +72,27 @@ class MLP_FORWARD(object):
       self.description = description
 
   '''
+  Given an input dict of options, return an output string that can be passed to
+  the program.
+  '''
+  def OptionsToStr(self, options):
+    optionsStr = ""
+    if "input_size" in options:
+      optionsStr = "--input_size " + str(options.pop("input_size"))
+    if "hidden_size" in options:
+      optionsStr = optionsStr + " --hidden_size " +
+          str(options.pop("hidden_size"))
+    if "output_size" in options:
+      optionsStr = optionsStr + " --output_size " +
+          str(options.pop("output_size"))
+
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters:" + str(options))
+      raise Exception("unknown parameters")
+
+    return optionsStr
+
+  '''
   Perform the linear forward pass. If the method has been successfully
   completed return the elapsed time in seconds.
 
@@ -83,7 +104,8 @@ class MLP_FORWARD(object):
     Log.Info("Perform MLP Forward.", self.verbose)
 
     # Split the command using shell-like syntax.
-    cmd = shlex.split(self.path + "mlp_forward -v " + options)
+    cmd = shlex.split(self.path + "mlp_forward -v " +
+        self.OptionsToStr(options))
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/mlpack/nbc.py
+++ b/methods/mlpack/nbc.py
@@ -90,6 +90,22 @@ class NBC(object):
         os.remove(f)
 
   '''
+  Given an input dict of options, convert it to a string that the program can
+  use.
+  '''
+  def OptionsToStr(self, options):
+    optionsStr = ""
+    if "incremental" in options:
+      optionsStr = "-I"
+      options.pop("incremental")
+
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
+    return optionsStr
+
+  '''
   Run valgrind massif profiler on the Parametric Naive Bayes Classifier method.
   If the method has been successfully completed the report is saved in the
   specified file.
@@ -109,7 +125,7 @@ class NBC(object):
 
     # Split the command using shell-like syntax.
     cmd = shlex.split(self.debug + "mlpack_nbc -t " + self.dataset[0] + " -T "
-        + self.dataset[1] + " -v " + options)
+        + self.dataset[1] + " -v " + self.OptionsToStr(options))
 
     return Profiler.MassifMemoryUsage(cmd, fileName, self.timeout, massifOptions)
 
@@ -130,7 +146,8 @@ class NBC(object):
 
     # Split the command using shell-like syntax.
     cmd = shlex.split(self.path + "mlpack_nbc -t " + self.dataset[0] + " -T "
-        + self.dataset[1] + " -v " + options + " -o output.csv")
+        + self.dataset[1] + " -v " + self.OptionsToStr(options) + " -o "
+        + "output.csv")
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/mlpack/nca.py
+++ b/methods/mlpack/nca.py
@@ -82,6 +82,32 @@ class NCA(object):
         os.remove(f)
 
   '''
+  Given an input dict of options, return an output string that the program can
+  use.
+  '''
+  def OptionsToStr(self, options):
+    optionsStr = ""
+    if "optimizer" in options:
+      optionsStr = "-O " + str(options.pop("optimizer"))
+    if "max_iterations" in options:
+      optionsStr = optionsStr + " -n " + str(options.pop("max_iterations"))
+    if "num_basis" in options:
+      optionsStr = optionsStr + " -B " + str(options.pop("num_basis"))
+    if "wolfe" in options:
+      optionsStr = optionsStr + " -w " + str(options.pop("wolfe"))
+    if "normalize" in options:
+      optionsStr = optionsStr + " -N"
+      options.pop("normalize")
+    if "seed" in options:
+      optionsStr = optionsStr + " --seed " + str(options.pop("seed"))
+
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
+    return optionsStr
+
+  '''
   Run valgrind massif profiler on the Neighborhood Components Analysis method.
   If the method has been successfully completed the report is saved in the
   specified file.
@@ -99,10 +125,11 @@ class NCA(object):
     # In this case we add this to the command line.
     if len(self.dataset) == 2:
       cmd = shlex.split(self.debug + "mlpack_nca -i " + self.dataset[0] + " -l "
-          + self.dataset[1] + " -v -o distance.csv " + options)
+          + self.dataset[1] + " -v -o distance.csv "
+          + self.OptionsToStr(options))
     else:
       cmd = shlex.split(self.debug + "mlpack_nca -i " + self.dataset +
-          " -v -o distance.csv " + options)
+          " -v -o distance.csv " + self.OptionsToStr(options))
 
     return Profiler.MassifMemoryUsage(cmd, fileName, self.timeout, massifOptions)
 
@@ -121,10 +148,11 @@ class NCA(object):
     # In this case we add this to the command line.
     if len(self.dataset) == 2:
       cmd = shlex.split(self.path + "mlpack_nca -i " + self.dataset[0] + " -l "
-          + self.dataset[1] + " -v -o distance.csv " + options)
+          + self.dataset[1] + " -v -o distance.csv "
+          + self.OptionsToStr(options))
     else:
       cmd = shlex.split(self.path + "mlpack_nca -i " + self.dataset +
-          " -v -o distance.csv " + options)
+          " -v -o distance.csv " + self.OptionsToStr(options))
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/mlpack/nmf.py
+++ b/methods/mlpack/nmf.py
@@ -82,6 +82,29 @@ class NMF(object):
         os.remove(f)
 
   '''
+  Given an input dict of options, convert them to a string that the program can
+  use.
+  '''
+  def OptionsToStr(self, options):
+    optionsStr = ""
+    if "rank" in options:
+      optionsStr = "-r " + str(options.pop("rank"))
+    else:
+      Log.Fatal("Required parameter 'rank' not specified!")
+      raise Exception("missing parameter")
+
+    if "update_rules" in options:
+      optionsStr = optionsStr + " -u " + str(options.pop("update_rules"))
+    if "seed" in options:
+      optionsStr = optionsStr + " -s " + str(options.pop("seed"))
+
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
+    return optionsStr
+
+  '''
   Run valgrind massif profiler on the Non-negative Matrix Factorization method.
   If the method has been successfully completed the report is saved in the
   specified file.
@@ -97,7 +120,7 @@ class NMF(object):
 
     # Split the command using shell-like syntax.
     cmd = shlex.split(self.debug + "mlpack_nmf -i " + self.dataset +
-        " -H H.csv -W W.csv -v " + options)
+        " -H H.csv -W W.csv -v " + self.OptionsToStr(options))
 
     return Profiler.MassifMemoryUsage(cmd, fileName, self.timeout, massifOptions)
 
@@ -114,7 +137,7 @@ class NMF(object):
 
     # Split the command using shell-like syntax.
     cmd = shlex.split(self.path + "mlpack_nmf -i " + self.dataset +
-        " -H H.csv -W W.csv -v " + options)
+        " -H H.csv -W W.csv -v " + self.OptionsToStr(options))
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/mlpack/pca.py
+++ b/methods/mlpack/pca.py
@@ -95,9 +95,13 @@ class PCA(object):
   def RunMemory(self, options, fileName, massifOptions="--depth=2"):
     Log.Info("Perform PCA Memory Profiling.", self.verbose)
 
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
     # Split the command using shell-like syntax.
     cmd = shlex.split(self.debug + "mlpack_pca -i " + self.dataset +
-        " -o output.csv -v " + options)
+        " -o output.csv -v")
 
     return Profiler.MassifMemoryUsage(cmd, fileName, self.timeout, massifOptions)
 
@@ -112,9 +116,13 @@ class PCA(object):
   def RunMetrics(self, options):
     Log.Info("Perform PCA.", self.verbose)
 
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
     # Split the command using shell-like syntax.
     cmd = shlex.split(self.path + "mlpack_pca -i " + self.dataset +
-        " -o output.csv -v " + options)
+        " -o output.csv -v")
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/mlpack/perceptron.py
+++ b/methods/mlpack/perceptron.py
@@ -90,6 +90,20 @@ class PERCEPTRON(object):
         os.remove(f)
 
   '''
+  Given an input dict of options, convert it to a string that the program can
+  use.
+  '''
+  def OptionsToStr(self, options):
+    optionsStr = ""
+    if "max_iterations" in options:
+      optionsStr = "-n " + str(options.pop("max_iterations"))
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters:" + str(options))
+      raise Exception("unknown parameters")
+
+    return optionsStr
+
+  '''
   Run valgrind massif profiler on the Perceptron Prediction
   method. If the method has been successfully completed the report is saved in
   the specified file.
@@ -107,7 +121,7 @@ class PERCEPTRON(object):
     # In this case we add this to the command line.
     if len(self.dataset) >= 2:
       cmd = shlex.split(self.debug + "mlpack_perceptron -t " + self.dataset[0] +
-          " -T " + self.dataset[1] + " -v " + options)
+          " -T " + self.dataset[1] + " -v " + self.OptionsToStr(options))
     else:
       Log.Fatal("This method requires atleast two datasets.")
 
@@ -127,8 +141,9 @@ class PERCEPTRON(object):
     # If the dataset contains two files then the second file is the labels file.
     # In this case we add this to the command line.
     if len(self.dataset) >= 2:
-      cmd = shlex.split(self.path + "mlpack_perceptron -t " + self.dataset[0] +
-          " -T " + self.dataset[1] + " -v " + options + " -o output.csv")
+      cmd = shlex.split(self.path + "mlpack_perceptron -t " + self.dataset[0]
+          + " -T " + self.dataset[1] + " -v " + self.OptionsToStr(options)
+          + " -o output.csv")
     else:
       Log.Fatal("This method requires atleast two datasets.")
 

--- a/methods/mlpack/range_search.py
+++ b/methods/mlpack/range_search.py
@@ -99,6 +99,8 @@ class RANGESEARCH(object):
       optionsStr = optionsStr + " --naive_mode"
       options.pop("naive_mode")
 
+    return optionsStr
+
   '''
   Run valgrind massif profiler on the Range Search method. If
   the method has been successfully completed the report is saved in the

--- a/methods/mlpack/range_search.py
+++ b/methods/mlpack/range_search.py
@@ -82,6 +82,24 @@ class RANGESEARCH(object):
         os.remove(f)
 
   '''
+  Given an input dict of options, convert them to a string the program can use.
+  '''
+  def OptionsToStr(self, options):
+    optionsStr = ""
+    if "max" in options:
+      optionsStr = "-M " + str(options.pop("max"))
+    else:
+      Log.Fatal("Required parameter 'max' not specified!")
+      raise Exception("missing parameter")
+
+    if "single_mode" in options:
+      optionsStr = optionsStr + " --single_mode"
+      options.pop("single_mode")
+    if "naive_mode" in options:
+      optionsStr = optionsStr + " --naive_mode"
+      options.pop("naive_mode")
+
+  '''
   Run valgrind massif profiler on the Range Search method. If
   the method has been successfully completed the report is saved in the
   specified file.
@@ -100,10 +118,10 @@ class RANGESEARCH(object):
     if len(self.dataset) == 2:
       cmd = shlex.split(self.debug + "mlpack_range_search -r " + self.dataset[0]
           + "-q " + self.dataset[1] + " -v -n neighbors.csv -d distances.csv " +
-          options)
+          self.OptionsToStr(options))
     else:
       cmd = shlex.split(self.debug + "mlpack_range_search -r " + self.dataset +
-          " -v -n neighbors.csv -d distances.csv " + options)
+          " -v -n neighbors.csv -d distances.csv " + self.OptionsToStr(options))
 
     return Profiler.MassifMemoryUsage(cmd, fileName, self.timeout, massifOptions)
 
@@ -123,10 +141,10 @@ class RANGESEARCH(object):
     if len(self.dataset) == 2:
       cmd = shlex.split(self.path + "mlpack_range_search -r " + self.dataset[0]
           + "-q " + self.dataset[1] + " -v -n neighbors.csv -d distances.csv " +
-          options)
+          self.OptionsToStr(options))
     else:
       cmd = shlex.split(self.path + "mlpack_range_search -r " + self.dataset +
-          " -v -n neighbors.csv -d distances.csv " + options)
+          " -v -n neighbors.csv -d distances.csv " + self.OptionsToStr(options))
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/mlpack/sparse_coding.py
+++ b/methods/mlpack/sparse_coding.py
@@ -82,6 +82,31 @@ class SparseCoding(object):
         os.remove(f)
 
   '''
+  Given an input dict of options, convert to a string that the program can use.
+  '''
+  def OptionsToStr(self, options):
+    optionsStr = ""
+    if "atoms" in options:
+      optionsStr = "-k " + str(options.pop("atoms"))
+    else:
+      Log.Fatal("Required parameter 'atoms' not specified!")
+      raise Exception("missing parameter")
+
+    if "seed" in options:
+      optionsStr = optionsStr + " -s " + str(options.pop("seed"))
+    if "max_iterations" in options:
+      optionsStr = optionsStr + " -n " + str(options.pop("max_iterations"))
+    if "normalize" in options:
+      optionsStr = optionsStr + " -N"
+      options.pop("normalize")
+
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
+    return optionsStr
+
+  '''
   Run valgrind massif profiler on the Sparse Coding method. If the method has
   been successfully completed the report is saved in the specified file.
 
@@ -98,10 +123,11 @@ class SparseCoding(object):
     # dictionary. In this case we add this to the command line.
     if len(self.dataset) == 2:
       cmd = shlex.split(self.debug + "mlpack_sparse_coding -i " +
-          self.dataset[0] + " -D " + self.dataset[1] + " -v " + options)
+          self.dataset[0] + " -D " + self.dataset[1] + " -v " +
+          self.OptionsToStr(options))
     else:
         cmd = shlex.split(self.debug + "mlpack_sparse_coding -i " + self.dataset
-            + " -v " + options)
+            + " -v " + self.OptionsToStr(options))
 
     return Profiler.MassifMemoryUsage(cmd, fileName, self.timeout, massifOptions)
 
@@ -120,10 +146,10 @@ class SparseCoding(object):
     # dictionary. In this case we add this to the command line.
     if len(self.dataset) == 2:
       cmd = shlex.split(self.path + "mlpack_sparse_coding -t " + self.dataset[0]
-          + " -i " + self.dataset[1] + " -v " + options)
+          + " -i " + self.dataset[1] + " -v " + self.OptionsToStr(options))
     else:
       cmd = shlex.split(self.path + "mlpack_sparse_coding -t " + self.dataset +
-          " -v " + options)
+          " -v " + self.OptionsToStr(options))
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/mlpy/allknn.py
+++ b/methods/mlpy/allknn.py
@@ -67,18 +67,21 @@ class ALLKNN(object):
       try:
         with totalTimer:
           # Get all the parameters.
-          k = re.search("-k (\d+)", options)
-          if not k:
+          if not "k" in options:
             Log.Fatal("Required option: Number of furthest neighbors to find.")
             q.put(-1)
             return -1
           else:
-            k = int(k.group(1))
+            k = options.pop("k")
             if (k < 1 or k > referenceData.shape[0]):
-              Log.Fatal("Invalid k: " + k.group(1) + "; must be greater than 0 "
+              Log.Fatal("Invalid k: " + k + "; must be greater than 0 "
                 + "and less or equal than " + str(referenceData.shape[0]))
               q.put(-1)
               return -1
+
+          if len(options) > 0:
+            Log.Fatal("Unknown parameters: " + str(options))
+            raise Exception("unknown parameters")
 
           # Perform All K-Nearest-Neighbors.
           model = mlpy.KNN(k)

--- a/methods/mlpy/decision_tree.py
+++ b/methods/mlpy/decision_tree.py
@@ -50,7 +50,12 @@ class DECISIONTREE(object):
   '''
   def BuildModel(self, data, labels):
     # Create and train the classifier.
-    DC = mlpy.ClassTree(stumps=self.stumps, minsize=self.minsize)
+    options = {}
+    if self.stumps:
+      options["stumps"] = self.stumps
+    if self.minsize:
+      options["minsize"] = self.minsize
+    DC = mlpy.ClassTree(**options)
     DC.learn(data, labels)
     return DC
 
@@ -69,11 +74,13 @@ class DECISIONTREE(object):
       testData = LoadDataset(self.dataset[1])
 
       # Get all the parameters.
-      s = re.search("--stumps (\d+)", options)
-      m = re.search("-m (\d+)", options)
-
-      self.stumps = 0 if not s else int(s.group(1))
-      self.minsize = 1 if not m else int(m.group(1))
+      if "stumps" in options:
+        self.stumps = options.pop("stumps")
+      if "minimum_leaf_size" in options:
+        self.minsize = options.pop("minimum_leaf_size")
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
 
       try:
         with totalTimer:

--- a/methods/mlpy/elastic_net.py
+++ b/methods/mlpy/elastic_net.py
@@ -47,8 +47,7 @@ class ElasticNet(object):
     self.dataset = dataset
     self.timeout = timeout
     self.model = None
-    self.rho = 0.5
-    self.alpha = 0.5
+    self.build_options = {}
 
   '''
   Build the model for the Elastic Net Classifier.
@@ -59,8 +58,7 @@ class ElasticNet(object):
   '''
   def BuildModel(self, data, labels):
     # Create and train the classifier.
-    elasticNet = mlpy.ElasticNet(lmb=self.rho,
-                                 eps=self.alpha)
+    elasticNet = mlpy.ElasticNet(**self.build_options)
     elasticNet.learn(data, labels)
     return elasticNet
 
@@ -79,11 +77,14 @@ class ElasticNet(object):
       trainData, labels = SplitTrainData(self.dataset)
       testData = LoadDataset(self.dataset[1])
 
-      r = re.search("-r (\d+)", options)
-      a = re.search("-a (\d+)", options)
-
-      self.rho = 0.5 if not r else int(r.group(1))
-      self.alpha = 0.5 if not r else int(a.group(1))
+      self.build_options = {}
+      if "rho" in options:
+        self.build_options['lmb'] = float(options.pop("rho"))
+      if "alpha" in options:
+        self.build_options['eps'] = float(options.pop("alpha"))
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
 
       try:
         with totalTimer:

--- a/methods/mlpy/golub.py
+++ b/methods/mlpy/golub.py
@@ -69,6 +69,10 @@ class Golub(object):
   successful.
   '''
   def GolubMlpy(self, options):
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
     def RunGolubMlpy(q):
       totalTimer = Timer()
 

--- a/methods/mlpy/kernel_pca.py
+++ b/methods/mlpy/kernel_pca.py
@@ -64,7 +64,7 @@ class KPCA(object):
                 + "than existing dimensionality (" + str(data.shape[1]) + ")!")
               q.put(-1)
               return -1
-          if not dimension:
+          else:
             d = data.shape[0]
 
           # Get the kernel type and make sure it is valid.
@@ -103,6 +103,7 @@ class KPCA(object):
           model.learn(kernel)
           out = model.transform(kernel, k=d)
       except Exception as e:
+        Log.Fatal("Exception: " + str(e))
         q.put(-1)
         return -1
 

--- a/methods/mlpy/kernel_pca.py
+++ b/methods/mlpy/kernel_pca.py
@@ -57,40 +57,46 @@ class KPCA(object):
       try:
         with totalTimer:
           # Get the new dimensionality, if it is necessary.
-          dimension = re.search('-d (\d+)', options)
-          if not dimension:
-            d = data.shape[0]
-          else:
-            d = int(dimension.group(1))
+          if "new_dimensionality" in options:
+            d = int(options.pop("new_dimensionality"))
             if (d > data.shape[1]):
               Log.Fatal("New dimensionality (" + str(d) + ") cannot be greater "
                 + "than existing dimensionality (" + str(data.shape[1]) + ")!")
               q.put(-1)
               return -1
+          if not dimension:
+            d = data.shape[0]
 
           # Get the kernel type and make sure it is valid.
-          kernel = re.search("-k ([^\s]+)", options)
-          if not kernel:
-              Log.Fatal("Choose kernel type, valid choices are 'polynomial', " +
-                    "'gaussian', 'linear' and 'hyptan'.")
-              q.put(-1)
-              return -1
-          elif kernel.group(1) == "polynomial":
-            degree = re.search('-D (\d+)', options)
-            degree = 1 if not degree else int(degree.group(1))
+          if not "kernel" in options:
+            Log.Fatal("Choose kernel type, valid choices are 'polynomial', " +
+                  "'gaussian', 'linear' and 'hyptan'.")
+            q.put(-1)
+            return -1
+
+          if options["kernel"] == "polynomial":
+            if "degree" in options:
+              degree = int(options.pop("degree"))
+            else:
+              degree = 1
 
             kernel = mlpy.kernel_polynomial(data, data, d=degree)
-          elif kernel.group(1) == "gaussian":
+          elif options["kernel"] == "gaussian":
             kernel = mlpy.kernel_gaussian(data, data, sigma=2)
-          elif kernel.group(1) == "linear":
+          elif options["kernel"] == "linear":
             kernel = mlpy.kernel_linear(data, data)
-          elif kernel.group(1) == "hyptan":
+          elif options["kernel"] == "hyptan":
             kernel = mlpy.kernel_sigmoid(data, data)
           else:
             Log.Fatal("Invalid kernel type (" + kernel.group(1) + "); valid " +
                     "choices are 'polynomial', 'gaussian', 'linear' and 'hyptan'.")
             q.put(-1)
             return -1
+
+          options.pop("kernel")
+          if len(options) > 0:
+            Log.Fatal("Unknown parameters: " + str(options))
+            raise Exception("unknown parameters")
 
           # Perform Kernel Principal Components Analysis.
           model = mlpy.KPCA()

--- a/methods/mlpy/kmeans.py
+++ b/methods/mlpy/kmeans.py
@@ -55,27 +55,30 @@ class KMEANS(object):
       data = np.genfromtxt(self.dataset[0], delimiter=',')
 
       # Gather all parameters.
-      clusters = re.search('-c (\d+)', options)
-      seed = re.search("-s (\d+)", options)
+      if "clusters" in options:
+        clusters = int(options.pop("clusters"))
 
-      # Now do validation of options.
-      if not clusters:
-        Log.Fatal("Required option: Number of clusters or cluster locations.")
-        q.put(-1)
-        return -1
-      elif int(clusters.group(1)) < 1:
         Log.Fatal("Invalid number of clusters requested! Must be greater than or "
             + "equal to 1.")
         q.put(-1)
         return -1
+      else:
+        Log.Fatal("Required option: Number of clusters or cluster locations.")
+        q.put(-1)
+        return -1
+
+      build_opts = {}
+      if "seed" in options:
+        build_opts["seed"] = int(options.pop("seed"))
+
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
 
       try:
         with totalTimer:
           # Create the K-Means object and perform K-Means clustering.
-          if seed:
-            kmeans = mlpy.kmeans(data, int(clusters.group(1)), seed=int(seed.group(1)))
-          else:
-            kmeans = mlpy.kmeans(data, int(clusters.group(1)))
+          kmeans = mlpy.kmeans(data, clusters, **build_opts)
       except Exception as e:
         q.put(-1)
         return -1

--- a/methods/mlpy/kmeans.py
+++ b/methods/mlpy/kmeans.py
@@ -58,10 +58,11 @@ class KMEANS(object):
       if "clusters" in options:
         clusters = int(options.pop("clusters"))
 
-        Log.Fatal("Invalid number of clusters requested! Must be greater than or "
-            + "equal to 1.")
-        q.put(-1)
-        return -1
+        if clusters < 1:
+          Log.Fatal("Invalid number of clusters requested! Must be greater than or "
+              + "equal to 1.")
+          q.put(-1)
+          return -1
       else:
         Log.Fatal("Required option: Number of clusters or cluster locations.")
         q.put(-1)

--- a/methods/mlpy/knc.py
+++ b/methods/mlpy/knc.py
@@ -48,9 +48,6 @@ class KNC(object):
     self.timeout = timeout
     self.model = None
     self.n_neighbors = 5
-    self.algorithm = 'kd_tree'
-    self.leaf_size = 30
-    self.metric = 'minkowski'
 
   '''
   Build the model for the k-nearest neighbors Classifier.
@@ -81,9 +78,15 @@ class KNC(object):
       testData = LoadDataset(self.dataset[1])
 
       # Get all the parameters.
-      n = re.search("-n (\d+)", options)
+      if "k" in options:
+        self.n_neighbors = int(options.pop("k"))
+      else:
+        Log.Fatal("Required parameter 'k' not specified!")
+        raise Exception("missing parameter")
 
-      self.n_neighbors = 5 if not n else int(n.group(1))
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
 
       try:
         with totalTimer:

--- a/methods/mlpy/lars.py
+++ b/methods/mlpy/lars.py
@@ -47,6 +47,10 @@ class LARS(object):
   successful.
   '''
   def LARSMlpy(self, options):
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
     def RunLARSMlpy(q):
       totalTimer = Timer()
 

--- a/methods/mlpy/lda.py
+++ b/methods/mlpy/lda.py
@@ -69,6 +69,10 @@ class LDA(object):
   successful.
   '''
   def LDAMlpy(self, options):
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
     def RunLDAMlpy(q):
       totalTimer = Timer()
 

--- a/methods/mlpy/linear_regression.py
+++ b/methods/mlpy/linear_regression.py
@@ -69,6 +69,10 @@ class LinearRegression(object):
   successful.
   '''
   def LinearRegressionMlpy(self, options):
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
     def RunLinearRegressionMlpy(q):
       totalTimer = Timer()
 

--- a/methods/mlpy/pca.py
+++ b/methods/mlpy/pca.py
@@ -77,10 +77,11 @@ class PCA(object):
             raise Exception("unknown parameters")
 
           # Perform PCA.
-          prep = mlpy.PCA(whiten=s)
+          prep = mlpy.PCA(**build_opts)
           prep.learn(data)
           out = prep.transform(data, k)
       except Exception as e:
+        Log.Fatal("Exception: " + str(e))
         q.put(-1)
         return -1
 

--- a/methods/mlpy/pca.py
+++ b/methods/mlpy/pca.py
@@ -57,20 +57,24 @@ class PCA(object):
       try:
         with totalTimer:
           # Find out what dimension we want.
-          match = re.search('-d (\d+)', options)
-
-          if not match:
-            k = data.shape[1]
-          else:
-            k = int(match.group(1))
+          if "new_dimensionality" in options:
+            k = int(options.pop("new_dimensionality"))
             if (k > data.shape[1]):
               Log.Fatal("New dimensionality (" + str(k) + ") cannot be greater "
                   + "than existing dimensionality (" + str(data.shape[1]) + ")!")
               q.put(-1)
               return -1
+          else:
+            k = data.shape[1]
 
-          # Get the options for running PCA.
-          s = True if options.find("-s") > -1 else False
+          build_opts = {}
+          if "whiten" in options:
+            build_opts["whiten"] = True
+            options.pop("whiten")
+
+          if len(options) > 0:
+            Log.Fatal("Unknown parameters: " + str(options))
+            raise Exception("unknown parameters")
 
           # Perform PCA.
           prep = mlpy.PCA(whiten=s)

--- a/methods/mlpy/perceptron.py
+++ b/methods/mlpy/perceptron.py
@@ -58,9 +58,7 @@ class PERCEPTRON(object):
   '''
   def BuildModel(self, data, responses):
     # Create and train the classifier.
-    model = mlpy.Perceptron(alpha=0.1,
-                            thr=0.05,
-                            maxiters=self.iterations)
+    model = mlpy.Perceptron(**self.opts)
     model.learn(data, responses)
     return model
 
@@ -86,8 +84,15 @@ class PERCEPTRON(object):
       # Use the last row of the training set as the responses.
       X, y = SplitTrainData(self.dataset)
 
-      i = re.search('-n (\d+)', options)
-      self.iterations = 1000 if not i else int(i.group(1))
+      self.opts = {}
+      self.opts["alpha"] = 0.1
+      self.opts["thr"] = 0.05
+      if "max_iterations" in options:
+        self.opts["maxiters"] = int(options.pop("max_iterations"))
+
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
 
       try:
         with totalTimer:

--- a/methods/mlpy/svm.py
+++ b/methods/mlpy/svm.py
@@ -81,13 +81,24 @@ class SVM(object):
       trainData, labels = SplitTrainData(self.dataset)
       testData = LoadDataset(self.dataset[1])
 
-      k = re.search("-k (\s+)", options)
-      c = re.search("-c (\d+)", options)
-      g = re.search("-g (\d+)", options)
+      if "kernel" in options:
+        self.kernel = str(options.pop("kernel"))
+      else:
+        self.kernel = 'rbf'
 
-      self.kernel = 'rbf' if not k else str(k.group(1))
-      self.C = 1.0 if not c else float(c.group(1))
-      self.gamma = 0.0 if not g else float(g.group(1))
+      if "c" in options:
+        self.C = float(options.pop("c"))
+      else:
+        self.C = 1.0
+
+      if "gamma" in options:
+        self.gamma = float(options.pop("gamma"))
+      else:
+        self.gamma = 0.0
+
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
 
       try:
         with totalTimer:

--- a/methods/mrpt/ann.py
+++ b/methods/mrpt/ann.py
@@ -80,6 +80,8 @@ class ANN(object):
 
       if "depth" in options:
         build_dict["depth"] = int(options.pop("depth"))
+      else:
+        build_dict["depth"] = 2 # Not sure... just a default...
       if "votes_required" in options:
         run_dict["votes_required"] = int(options.pop("votes_required"))
 

--- a/methods/mrpt/ann.py
+++ b/methods/mrpt/ann.py
@@ -72,7 +72,7 @@ class ANN(object):
       build_dict = {}
       run_dict = {}
       if "num_trees" in options:
-        build_dict["n_trees"] = int(options.pop("num_trees")
+        build_dict["n_trees"] = int(options.pop("num_trees"))
       else:
         Log.Fatal("Required option: Number of trees to build")
         q.put(-1)

--- a/methods/mrpt/ann.py
+++ b/methods/mrpt/ann.py
@@ -57,42 +57,46 @@ class ANN(object):
       train, label = SplitTrainData(self.dataset)
 
       # Get all the parameters.
-      k = re.search("-k (\d+)", options)
-      n = re.search("-n (\d+)", options) # Number of trees.
-      d = re.search("-d (\d+)", options) # The tree depth.
-      v = re.search("-v (\d+)", options) # Number of votes_required.
-
-      if not k:
-        Log.Fatal("Required option: Number of furthest neighbors to find.")
-        q.put(-1)
-        return -1
-      else:
-        k = int(k.group(1))
+      if "k" in options:
+        k = int(options.pop("k"))
         if (k < 1 or k > referenceData.shape[0]):
           Log.Fatal("Invalid k: " + k.group(1) + "; must be greater than 0"
             + " and less or equal than " + str(referenceData.shape[0]))
           q.put(-1)
           return -1
-      if not n:
-          Log.Fatal("Required option: Number of trees to build")
-          q.put(-1)
-          return -1
       else:
-          n=int(n.group(1))
+        Log.Fatal("Required option: Number of furthest neighbors to find.")
+        q.put(-1)
+        return -1
 
-      d = 5 if not d else int(d.group(1))
-      v = 4 if not v else int(v.group(1))
+      build_dict = {}
+      run_dict = {}
+      if "num_trees" in options:
+        build_dict["n_trees"] = int(options.pop("num_trees")
+      else:
+        Log.Fatal("Required option: Number of trees to build")
+        q.put(-1)
+        return -1
+
+      if "depth" in options:
+        build_dict["depth"] = int(options.pop("depth"))
+      if "votes_required" in options:
+        run_dict["votes_required"] = int(options.pop("votes_required"))
+
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
 
       with totalTimer:
         try:
           # Perform Approximate Nearest-Neighbors.
           acc = 0
-          index = mrpt.MRPTIndex(np.float32(train), depth=d, n_trees=n)
+          index = mrpt.MRPTIndex(np.float32(train), **build_dict)
           index.build()
           approximate_neighbors = np.zeros((len(queryData), k))
           for i in range(len(queryData)):
               approximate_neighbors[i] = index.ann(np.float32(queryData[i]), k,
-                  votes_required=v)
+                  **run_dict)
         except Exception as e:
           Log.Info(e)
           q.put(-1)

--- a/methods/nearpy/ann.py
+++ b/methods/nearpy/ann.py
@@ -47,6 +47,10 @@ class ANN(object):
   successful.
   '''
   def AnnNearpy(self, options):
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
     def RunAnnNearpy(q):
       totalTimer = Timer()
 
@@ -87,7 +91,7 @@ class ANN(object):
   def RunMetrics(self, options):
     Log.Info("Perform Approximate Nearest Neighbours.", self.verbose)
     results = None
-    if len(self.dataset)>=2:
+    if len(self.dataset) >= 2:
       results = self.AnnNearpy(options)
 
     if results < 0:

--- a/methods/scikit/LSHForest.py
+++ b/methods/scikit/LSHForest.py
@@ -95,7 +95,7 @@ class ANN(object):
         self.build_options["radius"] = float(options.pop("radius"))
       # A value ranges from 0 to 1.
       if "radius_cutoff_ratio" in options:
-        self.build_options["radius_cutoff_ratio"] =
+        self.build_options["radius_cutoff_ratio"] = \
             float(options.pop("radius_cutoff_ratio"))
 
       if len(options) > 0:

--- a/methods/scikit/LSHForest.py
+++ b/methods/scikit/LSHForest.py
@@ -45,8 +45,7 @@ class ANN(object):
     self.dataset = dataset
     self.timeout = timeout
     self.model = None
-    self.n_estimators = 10
-    self.n_neighbors = 5
+    self.build_opts = {}
 
   '''
   Build the model for the Approximate Nearest Neighbors.
@@ -57,12 +56,7 @@ class ANN(object):
   '''
   def BuildModel(self, data, labels):
     # Create and train the classifier.
-    lshf = LSHForest(n_estimators = self.n_estimators,
-                     min_hash_match = self.min_hash_match,
-                     n_candidates = self.n_candidates,
-                     radius_cutoff_ratio = self.radius_cutoff_ratio,
-                     radius = self.radius,
-                     n_neighbors = self.n_neighbors)
+    lshf = LSHForest(**self.build_opts)
     lshf.fit(data)
     return lshf
 
@@ -80,30 +74,40 @@ class ANN(object):
       Log.Info("Loading dataset", self.verbose)
       trainData, labels = SplitTrainData(self.dataset)
       testData = LoadDataset(self.dataset[1])
-      #Number of trees in the LSH Forest.
-      n_estimators = re.search("-n (\d+)", options)
-      #Number of neighbors to be returned from the query function.
-      n_neighbors = re.search("-k (\d+)", options)
-      #Lowest hash length to be searched when candidate selection is performed.
-      min_hash_match = re.search("-H (\d+)", options)
-      #Minimum number of candidates evaluated per estimator.
-      n_candidates = re.search("--n_candidates (\d+)", options)
-      #Radius from data point to its neighbors.
-      radius = re.search("--radius (\d+)", options)
-      #A value ranges from 0 to 1.
-      radius_cutoff_ratio = re.search("--radius_cutoff_ratio (\d+)", options)
-      self.n_estimators = 10 if not n_estimators else int(n_estimators.group(1))
-      self.n_neighbors = 5 if not n_neighbors else int(n_neighbors.group(1))
-      self.min_hash_match = 4 if not min_hash_match else int(min_hash_match.group(1))
-      self.n_candidates = 10 if not n_candidates else int(n_candidates.group(1))
-      self.radius = 1.0 if not radius else float(radius.group(1))
-      self.radius_cutoff_ratio = 0.9 if not radius_cutoff_ratio else float(radius_cutoff_ratio.group(1))
+      # Number of trees in the LSH Forest.
+      self.build_opts = {}
+      if "num_trees" in options:
+        self.build_opts["n_estimators"] = int(options.pop("n_estimators"))
+      # Number of neighbors to be returned from the query function.
+      if "k" in options:
+        n_neighbors = int(options.pop("k"))
+      else:
+        Log.Fatal("Required parameter 'k' not specified!")
+        raise Exception("missing parameter")
+      # Lowest hash length to be searched when candidate selection is performed.
+      if "min_hash_match" in options:
+        self.build_opts["min_hash_match"] = int(options.pop("min_hash_match"))
+      # Minimum number of candidates evaluated per estimator.
+      if "num_candidates" in options:
+        self.build_options["n_candidates"] = int(options.pop("n_candidates"))
+      # Radius from data point to its neighbors.
+      if "radius" in options:
+        self.build_options["radius"] = float(options.pop("radius"))
+      # A value ranges from 0 to 1.
+      if "radius_cutoff_ratio" in options:
+        self.build_options["radius_cutoff_ratio"] =
+            float(options.pop("radius_cutoff_ratio"))
+
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
+
       try:
         with totalTimer:
           self.model = self.BuildModel(trainData, labels)
           # Run Approximate on the test dataset.
           distances,indices = self.model.kneighbors(testData,
-                                                    n_neighbors = self.n_neighbors)
+                                                    n_neighbors=n_neighbors)
       except Exception as e:
         Log.Debug(str(e))
         q.put(-1)

--- a/methods/scikit/LSHForest.py
+++ b/methods/scikit/LSHForest.py
@@ -77,7 +77,7 @@ class ANN(object):
       # Number of trees in the LSH Forest.
       self.build_opts = {}
       if "num_trees" in options:
-        self.build_opts["n_estimators"] = int(options.pop("n_estimators"))
+        self.build_opts["n_estimators"] = int(options.pop("num_trees"))
       # Number of neighbors to be returned from the query function.
       if "k" in options:
         n_neighbors = int(options.pop("k"))

--- a/methods/scikit/adaboost.py
+++ b/methods/scikit/adaboost.py
@@ -47,10 +47,7 @@ class ADABOOST(object):
     self.dataset = dataset
     self.timeout = timeout
     self.model = None
-    self.n_estimators = 50
-    self.learning_rate = 1.0
-    self.algorithm = 'SAMME.R'
-    self.seed = 0
+    self.build_opts = {}
 
   '''
   Build the model for the AdaBoost classifier.
@@ -61,10 +58,7 @@ class ADABOOST(object):
   '''
   def BuildModel(self, data, labels):
     # Create and train the classifier.
-    adaboost = AdaBoostClassifier(n_estimators=self.n_estimators,
-                                  learning_rate=self.learning_rate,
-                                  algorithm=self.algorithm,
-                                  random_state=self.seed)
+    adaboost = AdaBoostClassifier(**self.build_opts)
     adaboost.fit(data, labels)
     return adaboost
 
@@ -84,15 +78,19 @@ class ADABOOST(object):
       testData = LoadDataset(self.dataset[1])
 
       # Get all the parameters.
-      e = re.search("-e (\d+)", options)
-      l = re.search("-l (\d+)", options)
-      a = re.search("-a (\s+)", options)
-      s = re.search("-n (\d+)", options)
+      self.build_opts = {}
+      if "num_estimators" in options:
+        self.build_opts["n_estimators"] = int(options.pop("num_estimators"))
+      if "learning_rate" in options:
+        self.build_opts["learning_rate"] = float(options.pop("learning_rate"))
+      if "algorithm" in options:
+        self.build_opts["algorithm"] = str(options.pop("algorithm"))
+      if "seed" in options:
+        self.build_opts["random_state"] = int(options.pop("seed"))
 
-      self.n_estimators = 50 if not e else int(e.group(1))
-      self.learning_rate = 1.0 if not l else float(l.group(1))
-      self.algorithm = 'SAMME.R' if not a else str(a.group(1))
-      self.seed = 0 if not s else int(s.group(1))
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
 
       try:
         with totalTimer:

--- a/methods/scikit/allknn.py
+++ b/methods/scikit/allknn.py
@@ -87,9 +87,9 @@ class ALLKNN(object):
 
         if "tree_type" in options:
           build_opts["tree_type"] = str(options.pop("tree_type"))
-          if build_opts["tree_type"] != 'auto' or
-             build_opts["tree_type"] != 'ball_tree' or
-             build_opts["tree_type"] != 'kd_tree' or
+          if build_opts["tree_type"] != 'auto' or \
+             build_opts["tree_type"] != 'ball_tree' or \
+             build_opts["tree_type"] != 'kd_tree' or \
              build_opts["tree_type"] != 'brute':
             Log.Fatal("Invalid tree type: "+ build_opts["tree_type"]
                 + ". Must be either auto, ball_tree, kd_tree or brute.")

--- a/methods/scikit/allknn.py
+++ b/methods/scikit/allknn.py
@@ -62,77 +62,71 @@ class ALLKNN(object):
 
       with totalTimer:
         # Get all the parameters.
-        k = re.search("-k (\d+)", options)
-        leafSize = re.search("-l (\d+)", options)
-        radius = re.search("--radius (\d+)", options)
-        tree_type = re.search("-t (\s+)", options)
-        metric = re.search("--metric (\s+)", options)
-        # Parameter for the Minkowski metric. 
-        # When p=1 it is equivalent to using manhattan_distance and euclidean for p=2. 
-        # For arbitrary p, minkowski_distance is used.
-        p = re.search("-p (\d+)", options)
-        n_jobs = re.search("--n_jobs (\d+)", options)
-        if not k:
-          Log.Fatal("Required option: Number of furthest neighbors to find.")
-          q.put(-1)
-          return -1
-        else:
-          k = int(k.group(1))
-          if (k < 1 or k > referenceData.shape[0]):
-            Log.Fatal("Invalid k: " + k.group(1) + "; must be greater than 0"
+        build_opts = {}
+        if "k" in options:
+          build_opts["n_neighbors"] = int(options.pop("k"))
+          if (build_opts["n_neighbors"] < 1 or build_opts["n_neighbors"] > referenceData.shape[0]):
+            Log.Fatal("Invalid k: " + str(build_opts["n_neighbors"]) + "; must be greater than 0"
               + " and less or equal than " + str(referenceData.shape[0]))
             q.put(-1)
             return -1
+        else:
+          Log.Fatal("Required option: Number of furthest neighbors to find.")
+          q.put(-1)
+          return -1
 
-        if not leafSize:
-          leafSize = 20
-        elif int(leafSize.group(1)) < 0:
-          Log.Fatal("Invalid leaf size: " + str(leafSize.group(1)) + ". Must" +
-              " be greater than or equal to 0.")
+        if "leaf_size" in options:
+          build_opts["leaf_size"] = int(options.pop("leaf_size"))
+          if build_opts["leaf_size"] < 0:
+            Log.Fatal("Invalid leaf size: " + str(build_opts["leaf_size"]) + ". Must" +
+                " be greater than or equal to 0.")
           q.put(-1)
           return -1
         else:
-          leafSize = int(leafSize.group(1))
-        if not tree_type:
-            tree_type = 'kd_tree'
-        elif str(tree_type.group(1)):
-            tree_type = str(tree_type.group(1))
-            if tree_type !='auto' or tree_type !='ball_tree' or tree_type != 'kd_tree' or tree_type != 'brute':
-                Log.Fatal("Invalid tree type: "+ str(tree_type.group(1)) 
-                          + ". Must be either auto, ball_tree, kd_tree or brute.")
-                q.put(-1)
-                return -1
-        radius = 1.0 if not radius else float(radius.group(1))
-        p = 2 if not p else int(p.group(1))
-        if not metric:
-            metric = 'minkowski'
-        elif metric.group(1):
-            metric = str(metric.group(1))
-            if metric not in ['cityblock', 'cosine', 'euclidean', 'l1', 'l2', 'manhattan']:
-                Log.Fatal("Invalid metric type: "+ str(metric.group(1))
-                          + ". Must be either cityblock, cosine, euclidean, l1, l2 or manhattan")
-                q.put(-1)
-                return -1
-        n_jobs = 1 if not n_jobs else int(n_jobs.group(1))
+          build_opts["leaf_size"] = 20
+
+        if "tree_type" in options:
+          build_opts["tree_type"] = str(options.pop("tree_type"))
+          if build_opts["tree_type"] != 'auto' or
+             build_opts["tree_type"] != 'ball_tree' or
+             build_opts["tree_type"] != 'kd_tree' or
+             build_opts["tree_type"] != 'brute':
+            Log.Fatal("Invalid tree type: "+ build_opts["tree_type"]
+                + ". Must be either auto, ball_tree, kd_tree or brute.")
+            q.put(-1)
+            return -1
+
+        if "radius" in options:
+          build_opts["radius"] = float(options.pop("radius"))
+        if "metric" in options:
+          build_opts["metric"] = str(options.pop("metric"))
+          if build_opts["metric"] not in ['cityblock', 'cosine', 'euclidean', 'l1', 'l2', 'manhattan']:
+            Log.Fatal("Invalid metric type: "+ build_opts["metric"]
+                + ". Must be either cityblock, cosine, euclidean, l1, l2 or manhattan")
+            q.put(-1)
+            return -1
+          if "p" in options:
+            build_opts["p"] = int(options.pop("p"))
+
+        if "num_jobs" in options:
+          build_opts["n_jobs"] = int(options.pop("num_jobs"))
+
+        if len(options) > 0:
+          Log.Fatal("Unknown parameters: " + str(options))
+          raise Exception("unknown parameters")
 
         try:
           # Perform All K-Nearest-Neighbors.
-          model = NearestNeighbors(n_neighbors=k, 
-                                   algorithm=tree_type, 
-                                   leaf_size=leafSize, 
-                                   radius=radius, 
-                                   metric=metric, 
-                                   p=p, 
-                                   n_jobs=n_jobs)
+          model = NearestNeighbors(**build_opts)
           model.fit(referenceData)
 
           if len(self.dataset) == 2:
-            out = model.kneighbors(queryData, k, return_distance=True)
+            out = model.kneighbors(queryData, build_opts["n_neighbors"], return_distance=True)
           else:
             # We have to increment k by one because mlpack ignores the
             # self-neighbor, whereas scikit-learn will happily return the
             # nearest neighbor of point 0 as point 0.
-            out = model.kneighbors(referenceData, k + 1, return_distance=True)
+            out = model.kneighbors(referenceData, build_opts["n_neighbors"] + 1, return_distance=True)
         except Exception as e:
           q.put(-1)
           return -1

--- a/methods/scikit/dtc.py
+++ b/methods/scikit/dtc.py
@@ -47,20 +47,7 @@ class DTC(object):
     self.dataset = dataset
     self.timeout = timeout
     self.model = None
-    self.criterion = 'gini'
-    self.max_depth = None
-    self.seed = 0
-    self.splitter = 'best'
-    self.max_depth = None
-    self.min_samples_split = 2
-    self.min_samples_leaf = 1
-    self.min_weight_fraction_leaf = 0.0
-    self.max_features = None
-    self.random_state = None
-    self.min_impurity_split = 1e-07
-    self.max_leaf_nodes = None
-    self.class_weight = None
-    self.presort = False
+    self.build_opts = {}
   '''
   Build the model for the Decision Tree Classifier.
 
@@ -70,17 +57,7 @@ class DTC(object):
   '''
   def BuildModel(self, data, labels):
     # Create and train the classifier.
-    dtc = DecisionTreeClassifier(criterion=self.criterion,
-                                 max_depth=self.max_depth,
-                                 random_state=self.seed,
-                                 splitter = self.splitter,
-                                 min_samples_split = self.min_samples_split,                                 
-                                 min_weight_fraction_leaf=self.min_weight_fraction_leaf,
-                                 max_features = self.max_features,
-                                 max_leaf_nodes = self.max_leaf_nodes,
-                                 min_impurity_split = self.min_impurity_split,
-                                 class_weight = self.class_weight,
-                                 presort = self.presort)
+    dtc = DecisionTreeClassifier(**self.build_opts)
     dtc.fit(data, labels)
     return dtc
 
@@ -100,22 +77,28 @@ class DTC(object):
       testData = LoadDataset(self.dataset[1])
 
       # Get all the parameters.
-      c = re.search("-c (\s+)", options)
-      d = re.search("-d (\s+)", options)
-      s = re.search("-s (\d+)", options)
-      mss = re.search("--min_samples_split (\d+)", options)
-      msl = re.search("--min_samples_leaf (\d+)", options)
-      mf = re.search("--max_features (\d+)", options)
-      mln = re.search("--max_leaf_nodes (\d+)", options)
-      
-      self.criterion = 'gini' if not c else str(c.group(1))
-      self.max_depth = None if not d else int(d.group(1))
-      self.splitter = 'best' if not s else str(s.group(1))
-      self.min_samples_split = 2 if not mss else int(mss.group(1))
-      self.min_samples_leaf = 1 if not msl else int(msl.group(1))
-      self.max_features = None if not mf else int(mf.group(1))
-      self.max_leaf_nodes = None if not mln else int(mln.group(1))
-      self.seed = 0 if not s else int(s.group(1))
+      self.build_opts = {}
+      if "fitness_function" in options:
+        self.build_opts["criterion"] = str(options.pop("criterion"))
+      if "max_depth" in options:
+        self.build_opts["max_depth"] = int(options.pop("max_depth"))
+      if "split_strategy" in options:
+        self.build_opts["splitter"] = str(options.pop("split_strategy"))
+      if "minimum_samples_split" in options:
+        self.build_opts["min_samples_split"] =
+            int(options.pop("minimum_samples_split"))
+      if "minimum_leaf_size" in options:
+        self.build_opts["min_samples_leaf"] = int(options.pop("minimum_leaf_size"))
+      if "max_features" in options:
+        self.build_opts["max_features"] = int(options.pop("max_features"))
+      if "max_leaf_nodes" in options:
+        self.build_opts["max_leaf_nodes"] = int(options.pop("max_leaf_nodes"))
+      if "seed" in options:
+        self.build_opts["random_state"] = int(options.pop("seed"))
+
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception('unknown parameters')
 
       try:
         with totalTimer:

--- a/methods/scikit/dtc.py
+++ b/methods/scikit/dtc.py
@@ -85,7 +85,7 @@ class DTC(object):
       if "split_strategy" in options:
         self.build_opts["splitter"] = str(options.pop("split_strategy"))
       if "minimum_samples_split" in options:
-        self.build_opts["min_samples_split"] =
+        self.build_opts["min_samples_split"] = \
             int(options.pop("minimum_samples_split"))
       if "minimum_leaf_size" in options:
         self.build_opts["min_samples_leaf"] = int(options.pop("minimum_leaf_size"))

--- a/methods/scikit/gmm.py
+++ b/methods/scikit/gmm.py
@@ -54,25 +54,26 @@ class GMM(object):
       dataPoints = np.genfromtxt(self.dataset, delimiter=',')
 
       # Get all the parameters.
-      g = re.search("-g (\d+)", options)
-      s = re.search("-s (\d+)", options)
-      tol = re.search("-T (\d+)", options)
-      n_init = re.search("-t (\d+)", options)
-      max_iter = re.search("-n (\d+)", options)
-      g = 1 if not g else int(g.group(1))
-      s = 0 if not s else int(s.group(1))
-      tol = 0.001 if not tol else float(tol.group(1))
-      max_iter = 100 if not max_iter else int(max_iter.group(1))
-      n_init = 1 if not n_init else int(n_init.group(1))
+      opts = {}
+      if "gaussians" in options:
+        opts["n_components"] = int(options.pop("gaussians"))
+      if "seed" in options:
+        opts["random_state"] = int(options.pop("seed"))
+      if "num_init" in options:
+        opts["n_init"] = int(options.pop("n_init"))
+      if "tolerance" in options:
+        opts["tol"] = float(options.pop("tolerance"))
+      if "max_iterations" in options:
+        opts["max_iter"] = int(options.pop("max_iterations"))
+
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
 
       try:
         # Create the Gaussian Mixture Model
-	      # Some params changed to match mlpack defaults.
-        model = mixture.GaussianMixture(n_components=g,
-                                        random_state=s,
-                                        n_init=n_init,
-                                        tol=tol,
-					max_iter = max_iter)
+        # Some params changed to match mlpack defaults.
+        model = mixture.GaussianMixture(**opts)
         with totalTimer:
           model.fit(dataPoints)
       except Exception as e:

--- a/methods/scikit/knc.py
+++ b/methods/scikit/knc.py
@@ -47,10 +47,7 @@ class KNC(object):
     self.dataset = dataset
     self.timeout = timeout
     self.model = None
-    self.n_neighbors = 5
-    self.algorithm = 'kd_tree'
-    self.leaf_size = 30
-    self.metric = 'minkowski'
+    self.opts = {}
 
   '''
   Build the model for the k-nearest neighbors Classifier.
@@ -61,10 +58,7 @@ class KNC(object):
   '''
   def BuildModel(self, data, labels):
     # Create and train the classifier.
-    knc = KNeighborsClassifier(n_neighbors=self.n_neighbors,
-                               algorithm=self.algorithm,
-                               leaf_size=self.leaf_size,
-                               metric=self.metric)
+    knc = KNeighborsClassifier(**self.opts)
     knc.fit(data, labels)
     return knc
 
@@ -84,15 +78,19 @@ class KNC(object):
       testData = LoadDataset(self.dataset[1])
 
       # Get all the parameters.
-      n = re.search("-n (\d+)", options)
-      a = re.search("-a (\s+)", options)
-      l = re.search("-l (\d+)", options)
-      m = re.search("-m (\s+)", options)
+      self.opts = {}
+      if "k" in options:
+        self.opts["n_neighbors"] = int(options.pop("k"))
+      if "algorithm" in options:
+        self.opts["algorithm"] = str(options.pop("algorithm"))
+      if "leaf_size" in options:
+        self.opts["leaf_size"] = int(options.pop("leaf_size"))
+      if "metric" in options:
+        self.opts["metric"] = str(options.pop("metric"))
 
-      self.n_neighbors = 5 if not n else int(n.group(1))
-      self.algorithm = 'kd_tree' if not a else str(a.group(1))
-      self.leaf_size = 30 if not l else int(l.group(1))
-      self.metric = 'minkowski' if not m else str(m.group(1))
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
 
       try:
         with totalTimer:

--- a/methods/scikit/lars.py
+++ b/methods/scikit/lars.py
@@ -54,18 +54,23 @@ class LARS(object):
       Log.Info("Loading dataset", self.verbose)
       inputData = np.genfromtxt(self.dataset[0], delimiter=',')
       responsesData = np.genfromtxt(self.dataset[1], delimiter=',')
-      lambda1 = re.search("-l (\d+)", options)
-      lambda1 = 1.0 if not lambda1 else float(lambda1.group(1))
-      max_iter1 = re.search("--max_iter (\d+)", options)
-      max_iter1 = 500 if not max_iter1 else int(max_iter1.group(1))
-      eps1 = re.search("--eps (\d+)", options)
-      eps1 = np.finfo(float).eps if not eps1 else float(eps1.group(1))
+
+      opts = {}
+      if "lambda1" in options:
+        opts["alpha"] = float(options.pop("lambda1"))
+      if "max_iterations" in options:
+        opts["max_iter"] = int(options.pop("max_iterations"))
+      if "epsilon" in options:
+        opts["eps"] = float(options.pop("epsilon"))
+
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
+
       try:
         with totalTimer:
           # Perform LARS.
-          model = LassoLars(alpha=lambda1,
-                            max_iter=max_iter1,
-                            eps = eps1)
+          model = LassoLars(**opts)
           model.fit(inputData, responsesData)
           out = model.coef_
       except Exception as e:

--- a/methods/scikit/lasso.py
+++ b/methods/scikit/lasso.py
@@ -56,8 +56,9 @@ class LASSO(object):
       responsesData = np.genfromtxt(self.dataset[1], delimiter=',')
 
       # Get all the parameters.
-      lambda1 = re.search("-l (\d+)", options)
-      lambda1 = 0.0 if not lambda1 else int(lambda1.group(1))
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
 
       try:
         with totalTimer:

--- a/methods/scikit/lda.py
+++ b/methods/scikit/lda.py
@@ -76,6 +76,10 @@ class LDA(object):
       trainData, labels = SplitTrainData(self.dataset)
       testData = LoadDataset(self.dataset[1])
 
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
+
       try:
         with totalTimer:
           self.model = self.BuildModel(trainData, labels)

--- a/methods/scikit/linear_regression.py
+++ b/methods/scikit/linear_regression.py
@@ -72,6 +72,10 @@ class LinearRegression(object):
     def RunLinearRegressionScikit(q):
       totalTimer = Timer()
 
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
+
       # Load input dataset.
       # If the dataset contains two files then the second file is the test file.
       Log.Info("Loading dataset", self.verbose)

--- a/methods/scikit/linear_ridge_regression.py
+++ b/methods/scikit/linear_ridge_regression.py
@@ -79,13 +79,18 @@ class LinearRidgeRegression(object):
 
       # Use the last row of the training set as the responses.
       X, y = SplitTrainData(self.dataset)
-      alpha = re.search("-t (\d+)", options)
-      alpha = 1.0 if not alpha else int(alpha.group(1))
+      opts = {}
+      if "alpha" in options:
+        opts["alpha"] = float(options.pop("alpha"))
+
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
 
       try:
         with totalTimer:
           # Perform linear ridge regression.
-          model = self.BuildModel(X,y, alpha=alpha)
+          model = self.BuildModel(X, y, **opts)
 
           if len(self.dataset) >= 2:
             model.predict(testSet)

--- a/methods/scikit/linear_ridge_regression.py
+++ b/methods/scikit/linear_ridge_regression.py
@@ -129,10 +129,15 @@ class LinearRidgeRegression(object):
 
       testData = LoadDataset(self.dataset[1])
       truelabels = LoadDataset(self.dataset[2])
-      alpha = re.search("-t (\d+)", options)
-      alpha = 1.0 if not alpha else int(alpha.group(1))
+      opts = {}
+      if "alpha" in options:
+        opts["alpha"] = float(options.pop("alpha"))
 
-      predictedlabels = np.rint(self.BuildModel(trainData, labels, alpha=alpha).predict(testData))
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
+
+      predictedlabels = np.rint(self.BuildModel(trainData, labels, **opts).predict(testData))
 
       SimpleMSE = Metrics.SimpleMeanSquaredError(truelabels, predictedlabels)
       metrics['Simple MSE'] = SimpleMSE

--- a/methods/scikit/logistic_regression.py
+++ b/methods/scikit/logistic_regression.py
@@ -47,8 +47,7 @@ class LogisticRegression(object):
     self.dataset = dataset
     self.timeout = timeout
     self.model = None
-    self.e = 1e-4
-    self.n = 100
+    self.opts = {}
 
   '''
   Build the model for the Logistic Regression.
@@ -59,8 +58,7 @@ class LogisticRegression(object):
   '''
   def BuildModel(self, data, responses):
     # Create and train the classifier.
-    lr = SLogisticRegression(max_iter = self.n, 
-                             tol = self.e)
+    lr = SLogisticRegression(**self.opts)
     lr.fit(data, responses)
     return lr
 
@@ -83,10 +81,16 @@ class LogisticRegression(object):
 
       # Use the last row of the training set as the responses.
       X, y = SplitTrainData(self.dataset)
-      e = re.search("-e (\d+)", options) #Tolerance
-      n = re.search("-n (\d+)", options) #Max_iterations
-      self.e = 1e-4 if not e else float(e.group(1))
-      self.n = 100 if not n else int(n.group(1))
+      if "algorithm" in options:
+        self.opts["algorithm"] = str(options.pop("algorithm"))
+      if "epsilon" in options:
+        self.opts["epsilon"] = float(options.pop("epsilon"))
+      if "max_iterations" in options:
+        self.opts["max_iter"] = int(options.pop("max_iter"))
+
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
 
       try:
         with totalTimer:

--- a/methods/scikit/nbc.py
+++ b/methods/scikit/nbc.py
@@ -76,6 +76,10 @@ class NBC(object):
       trainData, labels = SplitTrainData(self.dataset)
       testData = LoadDataset(self.dataset[1])
 
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
+
       try:
         with totalTimer:
           self.model = self.BuildModel(trainData, labels)

--- a/methods/scikit/pca.py
+++ b/methods/scikit/pca.py
@@ -57,23 +57,26 @@ class PCA(object):
       try:
         with totalTimer:
           # Find out what dimension we want.
-          match = re.search('-d (\d+)', options)
-
-          if not match:
-            k = data.shape[1]
-          else:
-            k = int(match.group(1))
-            if (k > data.shape[1]):
+          opts={}
+          if "new_dimensionality" in options:
+            opts["n_components"] = int(options.pop("new_dimensionality"))
+            if (opts["n_components"] > data.shape[1]):
               Log.Fatal("New dimensionality (" + str(k) + ") cannot be greater "
                   + "than existing dimensionality (" + str(data.shape[1]) + ")!")
               q.put(-1)
               return -1
+          else:
+            opts["n_components"] = data.shape[1]
+          if "whiten" in options:
+            opts["whiten"] = True
+            options.pop("whiten")
 
-          # Get the options for running PCA.
-          s = True if options.find("-s") > -1 else False
+          if len(options) > 0:
+            Log.Fatal("Unknown parameters: " + str(options))
+            raise Exception("unknown parameters")
 
           # Perform PCA.
-          pca = decomposition.PCA(n_components=k, whiten=s)
+          pca = decomposition.PCA(**opts)
           pca.fit(data)
           score = pca.transform(data)
       except Exception as e:

--- a/methods/scikit/perceptron.py
+++ b/methods/scikit/perceptron.py
@@ -47,7 +47,7 @@ class PERCEPTRON(object):
     self.dataset = dataset
     self.timeout = timeout
     self.model = None
-    self.iterations = 1000
+    self.opts = {}
 
   '''
   Build the model for the Perceptron.
@@ -58,7 +58,7 @@ class PERCEPTRON(object):
   '''
   def BuildModel(self, data, responses):
     # Create and train the classifier.
-    p = Perceptron(n_iter=self.iterations)
+    p = Perceptron(**opts)
     p.fit(data, responses)
     return p
 
@@ -82,8 +82,13 @@ class PERCEPTRON(object):
         Log.Fatal("This method requires atleast two datasets.")
 
       # Gather all parameters.
-      s = re.search('-n (\d+)', options)
-      self.iterations = 1000 if not s else int(s.group(1))
+      self.opts = {}
+      if "max_iterations" in options:
+        self.opts["n_iter"] = int(options.pop("max_iterations"))
+
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
 
       # Use the last row of the training set as the responses.
       X, y = SplitTrainData(self.dataset)
@@ -121,9 +126,7 @@ class PERCEPTRON(object):
 
     metrics = {'Runtime' : results}
 
-
     if len(self.dataset) >= 3:
-
       # Check if we need to create a model.
       if not self.model:
         trainData, labels = SplitTrainData(self.dataset)

--- a/methods/scikit/qda.py
+++ b/methods/scikit/qda.py
@@ -76,6 +76,10 @@ class QDA(object):
       trainData, labels = SplitTrainData(self.dataset)
       testData = LoadDataset(self.dataset[1])
 
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
+
       try:
         with totalTimer:
           self.model = self.BuildModel(trainData, labels)

--- a/methods/scikit/random_forest.py
+++ b/methods/scikit/random_forest.py
@@ -58,7 +58,7 @@ class RANDOMFOREST(object):
   '''
   def BuildModel(self, data, labels):
     # Create and train the classifier.
-    randomforest = RandomForestClassifier(**opts)
+    randomforest = RandomForestClassifier(**self.opts)
     randomforest.fit(data, labels)
     return randomforest
 
@@ -88,7 +88,7 @@ class RANDOMFOREST(object):
       if "seed" in options:
         self.opts["random_state"] = int(options.pop("seed"))
       if "minimum_samples_split" in options:
-        self.opts["min_samples_split"] =
+        self.opts["min_samples_split"] = \
             int(options.pop("minimum_samples_split"))
       if "minimum_leaf_size" in options:
         self.opts["min_samples_leaf"] = int(options.pop("minimum_leaf_size"))
@@ -105,6 +105,7 @@ class RANDOMFOREST(object):
           # Run Random Forest Classifier on the test dataset.
           self.model.predict(testData)
       except Exception as e:
+        Log.Fatal("Exception: " + str(e))
         q.put(-1)
         return -1
 

--- a/methods/scikit/random_forest.py
+++ b/methods/scikit/random_forest.py
@@ -47,21 +47,8 @@ class RANDOMFOREST(object):
     self.dataset = dataset
     self.timeout = timeout
     self.model = None
-    self.n_estimators = 10
-    self.criterion = 'gini'
-    self.max_depth = None
-    self.seed = 0
-    self.min_samples_split = 2
-    self.min_samples_leaf = 1
-    self.min_weight_fraction_leaf = 0.0
-    self.max_features = 'auto'
-    self.max_leaf_nodes = None
-    self.min_impurity_split = 1e-07
-    self.bootstrap = True
-    self.oob_score = False
-    self.n_jobs = 1
-    self.warm_start = False
-    self.class_weight = None
+    self.opts = {}
+
   '''
   Build the model for the Random Forest Classifier.
 
@@ -71,22 +58,7 @@ class RANDOMFOREST(object):
   '''
   def BuildModel(self, data, labels):
     # Create and train the classifier.
-    randomforest = RandomForestClassifier(
-        n_estimators = self.n_estimators,
-        max_depth = self.max_depth,
-        criterion = self.criterion,
-        random_state = self.seed,
-        min_samples_split = self.min_samples_split,
-        min_samples_leaf = self.min_samples_leaf,
-        min_weight_fraction_leaf = self.min_weight_fraction_leaf,
-        max_features = self.max_features,
-        max_leaf_nodes = self.max_leaf_nodes,
-        min_impurity_split = self.min_impurity_split,
-        bootstrap = self.bootstrap,
-        oob_score = self.oob_score,
-        n_jobs = self.n_jobs,
-        warm_start = self.warm_start,
-        class_weight = self.class_weight)
+    randomforest = RandomForestClassifier(**opts)
     randomforest.fit(data, labels)
     return randomforest
 
@@ -106,21 +78,27 @@ class RANDOMFOREST(object):
       testData = LoadDataset(self.dataset[1])
 
       # Get all the parameters.
-      e = re.search("-e (\d+)", options)
-      c = re.search("-c (\s+)", options)
-      d = re.search("-d (\s+)", options)
-      s = re.search("-s (\d+)", options)
-      mss = re.search("--min_samples_split (\d+)", options)
-      msl = re.search("--min_samples_leaf (\d+)", options)
-      nj = re.search("--n_jobs (\d+)", options)
+      self.opts = {}
+      if "num_trees" in options:
+        self.opts["n_estimators"] = int(options.pop("num_trees"))
+      if "fitness_function" in options:
+        self.opts["criterion"] = str(options.pop("fitness_function"))
+      if "max_depth" in options:
+        self.opts["max_depth"] = int(options.pop("max_depth"))
+      if "seed" in options:
+        self.opts["random_state"] = int(options.pop("seed"))
+      if "minimum_samples_split" in options:
+        self.opts["min_samples_split"] =
+            int(options.pop("minimum_samples_split"))
+      if "minimum_leaf_size" in options:
+        self.opts["min_samples_leaf"] = int(options.pop("minimum_leaf_size"))
+      if "num_jobs" in options:
+        self.opts["n_jobs"] = int(options.pop("num_jobs"))
 
-      self.n_estimators = 50 if not e else int(e.group(1))
-      self.criterion = 'gini' if not c else str(c.group(1))
-      self.max_depth = None if not d else int(d.group(1))
-      self.seed = 0 if not s else int(s.group(1))
-      self.min_samples_split = 2 if not mss else int(mss.group(1))
-      self.min_samples_leaf = 1 if not msl else int(msl.group(1))
-      self.n_jobs = 1 if not nj else int(nj.group(1))
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
+
       try:
         with totalTimer:
           self.model = self.BuildModel(trainData, labels)

--- a/methods/scikit/sparse_coding.py
+++ b/methods/scikit/sparse_coding.py
@@ -55,16 +55,22 @@ class SparseCoding(object):
       dictionary = np.genfromtxt(self.dataset[1], delimiter=',')
 
       # Get all the parameters.
-      l = re.search("-l (\d+)", options)
-      max_iter = re.search("-n (\d+)", options)
-      l = 0 if not l else int(l.group(1))
-      max_iter = 1000 if not max_iter else int(max_iter.group(1)) 
+      opts = {}
+      if "lambda" in options:
+        opts["transform_alpha"] = options.pop("lambda")
+      if "max_iterations" in options:
+        opts["max_iter"] = options.pop("max_iterations")
+      opts["transform_algorithm"] = "lars"
+      opts["dictionary"] = dictionary
+
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
 
       try:
         with totalTimer:
           # Perform Sparse Coding.
-          model = SparseCoder(dictionary=dictionary, transform_algorithm='lars',
-              transform_alpha=l, max_iter = max_iter)
+          model = SparseCoder(**opts)
           code = model.transform(inputData)
       except Exception as e:
         q.put(-1)

--- a/methods/scikit/svm.py
+++ b/methods/scikit/svm.py
@@ -47,13 +47,7 @@ class SVM(object):
     self.dataset = dataset
     self.timeout = timeout
     self.model = None
-    self.kernel = 'rbf'
-    self.C = 1.0
-    self.gamma = 'auto'
-    self.degree = 3
-    self.cache_size = 200
-    self.max_iter = -1
-    self.decision_function_shape = None
+    self.opts = {}
 
   '''
   Build the model for the Support vector machines.
@@ -64,13 +58,7 @@ class SVM(object):
   '''
   def BuildModel(self, data, labels):
     # Create and train the classifier.
-    svm = ssvm.SVC(kernel=self.kernel,
-                   C=self.C,
-                   gamma = self.gamma,
-                   degree=self.degree,
-                   cache_size = self.cache_size,
-                   max_iter = self.max_iter,
-                   decision_function_shape = self.decision_function_shape)
+    svm = ssvm.SVC(**opts)
     svm.fit(data, labels)
     return svm
 
@@ -89,21 +77,26 @@ class SVM(object):
       trainData, labels = SplitTrainData(self.dataset)
       testData = LoadDataset(self.dataset[1])
 
-      k = re.search("-k (\s+)", options)
-      c = re.search("-c (\d+)", options)
-      g = re.search("-g (\d+)", options)
-      degree = re.search("--degree (\d+)", options)
-      cache_size = re.search("--cache_size (\d+)", options)
-      max_iter = re.search("--max_iter (\d+)", options)
-      decision_function_shape = re.search("--decision_function_shape (\d+)", options)
+      self.opts = {}
+      if "kernel" in options:
+        self.opts["kernel"] = str(options.pop("kernel"))
+      if "c" in options:
+        self.opts["C"] = float(options.pop("c"))
+      if "gamma" in options:
+        self.opts["gamma"] = float(options.pop("gamma"))
+      if "degree" in options:
+        self.opts["degree"] = int(options.pop("degree"))
+      if "cache_size" in options:
+        self.opts["cache_size"] = float(options.pop("cache_size"))
+      if "max_iterations" in options:
+        self.opts["max_iter"] = int(options.pop("max_iterations"))
+      if "decision_function_shape" in options:
+        self.opts["decision_function_shape"] =
+            str(options.pop("decision_function_shape"))
 
-      self.kernel = 'rbf' if not k else str(k.group(1))
-      self.C = 1.0 if not c else float(c.group(1))
-      self.gamma = 'auto' if not g else float(g.group(1))
-      self.degree = 3 if not degree else int(degree.group(1))
-      self.cache_size = 200.0 if not cache_size else float(cache_size.group(1))
-      self.max_iter = -1 if not max_iter else int(max_iter.group(1))
-      self.decision_function_shape = None if not decision_function_shape else str(decision_function_shape.group(1))
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
 
       try:
         with totalTimer:

--- a/methods/scikit/svr.py
+++ b/methods/scikit/svr.py
@@ -57,18 +57,23 @@ class SVR(object):
       X, y = SplitTrainData(self.dataset)
 
       # Get all the parameters.
-      c = re.search("-c (\d+\.\d+)", options)
-      e = re.search("-e (\d+\.\d+)", options)
-      g = re.search("-g (\d+\.\d+)", options)
+      opts = {}
+      if "c" in options:
+        opts["C"] = float(options.pop("c"))
+      if "epsilon" in options:
+        opts["epsilon"] = float(options.pop("epsilon"))
+      if "gamma" in options:
+        opts["gamma"] = float(options.pop("gamma"))
+      opts["kernel"] = "rbf"
 
-      C = 1.0 if not c else float(c.group(1))
-      epsilon = 1.0 if not e else float(e.group(1))
-      gamma = 0.1 if not g else float(g.group(1))
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
 
       try:
         with totalTimer:
           # Perform SVR.
-          model = SSVR(kernel='rbf', C=C, epsilon=epsilon, gamma=gamma)
+          model = SSVR(**opts)
           model.fit(X, y)
       except Exception as e:
         q.put(-1)

--- a/methods/shogun/allknn.py
+++ b/methods/shogun/allknn.py
@@ -69,18 +69,21 @@ class ALLKNN(object):
 
         with totalTimer:
           # Get all the parameters.
-          k = re.search("-k (\d+)", options)
-          if not k:
-            Log.Fatal("Required option: Number of furthest neighbors to find.")
-            q.put(-1)
-            return -1
-          else:
-            k = int(k.group(1))
+          if "k" in options:
+            k = int(options.pop("k"))
             if (k < 1 or k > referenceData.shape[0]):
               Log.Fatal("Invalid k: " + k.group(1) + "; must be greater than 0"
                 + " and less or equal than " + str(referenceData.shape[0]))
               q.put(-1)
               return -1
+          else:
+            Log.Fatal("Required option: Number of furthest neighbors to find.")
+            q.put(-1)
+            return -1
+
+          if len(options) > 0:
+            Log.Fatal("Unknown parameters: " + str(options))
+            raise Exception("unknown parameters")
 
           referenceFeat = RealFeatures(referenceData.T)
           distance = EuclideanDistance(referenceFeat, referenceFeat)

--- a/methods/shogun/decision_tree.py
+++ b/methods/shogun/decision_tree.py
@@ -77,6 +77,10 @@ class DTC(object):
       labels = MulticlassLabels(labels)
       testData = RealFeatures(LoadDataset(self.dataset[1]).T)
 
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
+
       try:
         with totalTimer:
           self.model = self.BuildModel(trainData, labels, options)

--- a/methods/shogun/gmm.py
+++ b/methods/shogun/gmm.py
@@ -58,12 +58,17 @@ class GMM(object):
         dataFeat = RealFeatures(dataPoints.T)
 
         # Get all the parameters.
-        g = re.search("-g (\d+)", options)
-        n = re.search("-n (\d+)", options)
-        s = re.search("-n (\d+)", options)
+        if "gaussians" in options:
+          g = int(options.pop("gaussians"))
+        else:
+          Log.Fatal("Required parameter 'gaussians' not specified!")
+          raise Exception("missing parameter")
+        if "max_iterations" in options:
+          n = int(options.pop("max_iterations"))
 
-        g = 1 if not g else int(g.group(1))
-        n = 250 if not n else int(n.group(1))
+        if len(options) > 0:
+          Log.Fatal("Unknown parameters: " + str(options))
+          raise Exception("unknown parameters")
 
         # Create the Gaussian Mixture Model.
         model = SGMM(g)

--- a/methods/shogun/gmm.py
+++ b/methods/shogun/gmm.py
@@ -65,6 +65,8 @@ class GMM(object):
           raise Exception("missing parameter")
         if "max_iterations" in options:
           n = int(options.pop("max_iterations"))
+        else:
+          n = 0
 
         if len(options) > 0:
           Log.Fatal("Unknown parameters: " + str(options))
@@ -76,6 +78,7 @@ class GMM(object):
         with totalTimer:
           model.train_em(1e-9, n, 1e-9)
       except Exception as e:
+        Log.Info("Exception: " + str(e))
         q.put(-1)
         return -1
 

--- a/methods/shogun/kernel_pca.py
+++ b/methods/shogun/kernel_pca.py
@@ -59,34 +59,39 @@ class KPCA(object):
 
         with totalTimer:
           # Get the new dimensionality, if it is necessary.
-          dimension = re.search('-d (\d+)', options)
-          if not dimension:
-            d = data.shape[1]
-          else:
-            d = int(dimension.group(1))
+          if "new_dimensionality" in options:
+            d = int(options.pop("new_dimensionality"))
             if (d > data.shape[1]):
               Log.Fatal("New dimensionality (" + str(d) + ") cannot be greater "
                 + "than existing dimensionality (" + str(data.shape[1]) + ")!")
               q.put(-1)
               return -1
+          else:
+            d = data.shape[1]
 
           # Get the kernel type and make sure it is valid.
-          kernel = re.search("-k ([^\s]+)", options)
-          if not kernel:
-              Log.Fatal("Choose kernel type, valid choices are 'linear'," +
-                    " 'hyptan', 'polynomial' and 'gaussian'.")
-              q.put(-1)
-              return -1
-          elif kernel.group(1) == "polynomial":
-            degree = re.search('-D (\d+)', options)
-            degree = 1 if not degree else int(degree.group(1))
+          if "kernel" in options:
+            kernel = str(options.pop("kernel"))
+          else:
+            Log.Fatal("Choose kernel type, valid choices are 'linear'," +
+                  " 'hyptan', 'polynomial' and 'gaussian'.")
+            q.put(-1)
+            return -1
 
+          if "degree" in options:
+            degree = int(options.pop("degree"))
+
+          if len(options) > 0:
+            Log.Fatal("Unknown parameters: " + str(options))
+            raise Exception("unknown parameters")
+
+          if kernel == "polynomial":
             kernel = PolyKernel(dataFeat, dataFeat, degree, True)
-          elif kernel.group(1) == "gaussian":
+          elif kernel == "gaussian":
             kernel = GaussianKernel(dataFeat, dataFeat, 2.0)
-          elif kernel.group(1) == "linear":
+          elif kernel == "linear":
             kernel = LinearKernel(dataFeat, dataFeat)
-          elif kernel.group(1) == "hyptan":
+          elif kernel == "hyptan":
             kernel = SigmoidKernel(dataFeat, dataFeat, 2, 1.0, 1.0)
           else:
             Log.Fatal("Invalid kernel type (" + kernel.group(1) + "); valid "

--- a/methods/shogun/kmeans.py
+++ b/methods/shogun/kmeans.py
@@ -66,26 +66,24 @@ class KMEANS(object):
         data = np.genfromtxt(self.dataset[0], delimiter=',')
 
       # Gather parameters.
-      clusters = re.search("-c (\d+)", options)
-      maxIterations = re.search("-m (\d+)", options)
-      seed = re.search("-s (\d+)", options)
-
-      # Now do validation of options.
-      if not clusters and len(self.dataset) != 2:
+      if "clusters" in options:
+        clusters = int(options.pop("clusters"))
+      elif len(self.dataset) != 2:
         Log.Fatal("Required option: Number of clusters or cluster locations.")
         q.put(-1)
         return -1
-      elif (not clusters or int(clusters.group(1)) < 1) and len(self.dataset) != 2:
-        Log.Fatal("Invalid number of clusters requested! Must be greater than"
-            + " or equal to 1.")
-        q.put(-1)
-        return -1
+      if "max_iterations" in options:
+        maxIterations = int(options.pop("max_iterations"))
+      seed = None
+      if "seed" in options:
+        seed = int(options.pop("seed"))
 
-      m = 1000 if not maxIterations else int(maxIterations.group(1))
-
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
 
       if seed:
-        Math_init_random(seed.group(1))
+        Math_init_random(seed)
       try:
         dataFeat = RealFeatures(data.T)
         distance = EuclideanDistance(dataFeat, dataFeat)
@@ -93,9 +91,9 @@ class KMEANS(object):
         # Create the K-Means object and perform K-Means clustering.
         with totalTimer:
           if len(self.dataset) == 2:
-            model = KMeans(int(clusters.group(1)), distance, centroids.T)
+            model = KMeans(clusters, distance, centroids.T)
           else:
-            model = KMeans(int(clusters.group(1)), distance)
+            model = KMeans(clusters, distance)
 
           model.set_max_iter(m)
           model.train()

--- a/methods/shogun/knc.py
+++ b/methods/shogun/knc.py
@@ -47,7 +47,6 @@ class KNC(object):
     self.dataset = dataset
     self.timeout = timeout
     self.model = None
-    self.n_neighbors = 5
 
   '''
   Build the model for the k-nearest neighbors Classifier.
@@ -58,14 +57,19 @@ class KNC(object):
   '''
   def BuildModel(self, data, labels, options):
     # Get all the parameters.
-    n = re.search("-n (\d+)", options)
+    if "k" in options:
+      n_neighbors = int(options.pop("k"))
+    else:
+      Log.Fatal("Required parameter 'k' not specified!")
+      raise Exception("missing parameter")
 
-    self.n_neighbors = 5 if not n else int(n.group(1))
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
 
     distance = EuclideanDistance(data, data)
     from modshogun import KNN_KDTREE
-    knc = KNN(self.n_neighbors, distance, labels, KNN_KDTREE)
-    knc.set_leaf_size(30)
+    knc = KNN(n_neighbors, distance, labels, KNN_KDTREE)
     knc.train()
 
     return knc

--- a/methods/shogun/lars.py
+++ b/methods/shogun/lars.py
@@ -60,13 +60,19 @@ class LARS(object):
         responsesFeat = RegressionLabels(responsesData)
 
         # Get all the parameters.
-        lambda1 = re.search("-l (\d+)", options)
-        lambda1 = 0.0 if not lambda1 else int(lambda1.group(1))
+        lambda1 = None
+        if "lambda1" in options:
+          lambda1 = float(options.pop("lambda1"))
+
+        if len(options) > 0:
+          Log.Fatal("Unknown parameters: " + str(options))
+          raise Exception("unknown parameters")
 
         with totalTimer:
           # Perform LARS.
           model = LeastAngleRegression(False)
-          model.set_max_l1_norm(lambda1)
+          if lambda1:
+            model.set_max_l1_norm(lambda1)
           model.set_labels(responsesFeat)
           model.train(inputFeat)
           model.get_w_for_var(model.get_path_size() - 1)

--- a/methods/shogun/lasso.py
+++ b/methods/shogun/lasso.py
@@ -68,16 +68,22 @@ class LASSO(object):
         if len(self.dataset) >= 2:
           testSet = np.genfromtxt(self.dataset[1], delimiter=',')
 
-          # Get all the parameters.
-          lambda1 = re.search("-l (\d+)", options)
-          lambda1 = 0.0 if not lambda1 else int(lambda1.group(1))
+        # Get all the parameters.
+        lambda1 = None
+        if "lambda1" in options:
+          lambda1 = float(options.pop("lambda1"))
+
+        if len(options) > 0:
+          Log.Fatal("Unknown parameters: " + str(options))
+          raise Exception("unknown parameters")
 
         # Use the last row of the training set as the responses.
         X, y = SplitTrainData(self.dataset)
 
         with totalTimer:
           model = LeastAngleRegression(lasso=True)
-          model.set_max_l1_norm(lambda1)
+          if lambda1:
+            model.set_max_l1_norm(lambda1)
           model.set_labels(RegressionLabels(y))
           model.train(RealFeatures(X.T))
 

--- a/methods/shogun/linear_regression.py
+++ b/methods/shogun/linear_regression.py
@@ -71,6 +71,10 @@ class LinearRegression(object):
         # Use the last row of the training set as the responses.
         X, y = SplitTrainData(self.dataset)
 
+        if len(options) > 0:
+          Log.Fatal("Unknown parameters: " + str(options))
+          raise Exception("unknown parameters")
+
         with totalTimer:
           # Perform linear regression.
           model = LeastSquaresRegression(RealFeatures(X.T), RegressionLabels(y))

--- a/methods/shogun/linear_ridge_regression.py
+++ b/methods/shogun/linear_ridge_regression.py
@@ -117,8 +117,15 @@ class LinearRidgeRegression(object):
     if len(self.dataset) >= 3:
 
       X, y = SplitTrainData(self.dataset)
-      tau = re.search("-t (\d+)", options)
-      tau = 1.0 if not tau else int(tau.group(1))
+      if "alpha" in options:
+        tau = float(options.pop("alpha"))
+      else:
+        Log.Fatal("Required parameter 'alpha' not specified!")
+        raise Exception("missing parameter")
+
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
       model = LRR(tau, RealFeatures(X.T), RegressionLabels(y))
       model.train()
 

--- a/methods/shogun/linear_ridge_regression.py
+++ b/methods/shogun/linear_ridge_regression.py
@@ -68,8 +68,15 @@ class LinearRidgeRegression(object):
 
       # Use the last row of the training set as the responses.
       X, y = SplitTrainData(self.dataset)
-      tau = re.search("-t (\d+)", options)
-      tau = 1.0 if not tau else int(tau.group(1))
+      if "alpha" in options:
+        tau = float(options.pop("alpha"))
+      else:
+        Log.Fatal("Required parameter 'alpha' not specified!")
+        raise Exception("missing parameter")
+
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
 
       try:
         with totalTimer:

--- a/methods/shogun/logistic_regression.py
+++ b/methods/shogun/logistic_regression.py
@@ -86,8 +86,14 @@ class LogisticRegression(object):
         X, y = SplitTrainData(self.dataset)
 
         # Get the regularization value.
-        self.z = re.search("-l (\d+)", options)
-        self.z = 1 if not self.z else int(self.z.group(1))
+        if "lambda" in options:
+          self.z = float(options.pop("lambda"))
+        else:
+          self.z = 1
+
+        if len(options) > 0:
+          Log.Fatal("Unknown parameters: " + str(options))
+          raise Exception("unknown parameters")
 
         with totalTimer:
           # Perform logistic regression.

--- a/methods/shogun/nbc.py
+++ b/methods/shogun/nbc.py
@@ -63,6 +63,10 @@ class NBC(object):
         trainData = np.genfromtxt(self.dataset[0], delimiter=',')
         testData = np.genfromtxt(self.dataset[1], delimiter=',')
 
+        if len(options) > 0:
+          Log.Fatal("Unknown parameters: " + str(options))
+          raise Exception("unknown parameters")
+
         # Labels are the last row of the training set.
         labels = MulticlassLabels(trainData[:, (trainData.shape[1] - 1)])
 

--- a/methods/shogun/pca.py
+++ b/methods/shogun/pca.py
@@ -61,21 +61,26 @@ class PCA(object):
         feat = RealFeatures(self.data.T)
 
         with totalTimer:
-          # Find out what dimension we want.
-          match = re.search('-d (\d+)', options)
-
-          if not match:
-            k = self.data.shape[1]
-          else:
-            k = int(match.group(1))
+          # Get the options for running PCA.
+          if "new_dimensionality" in options:
+            k = int(options.pop("new_dimensionality"))
             if (k > self.data.shape[1]):
               Log.Fatal("New dimensionality (" + str(k) + ") cannot be greater than"
                   + "existing dimensionality (" + str(self.data.shape[1]) + ")!")
               q.put(-1)
               return -1
+          else:
+            k = self.data.shape[1]
 
-          # Get the options for running PCA.
-          s = True if options.find("-s") > -1 else False
+          if "whiten" in options:
+            s = True
+            options.pop("whiten")
+          else:
+            s = False
+
+          if len(options) > 0:
+            Log.Fatal("Unknown parameters: " + str(options))
+            raise Exception("unknown parameters")
 
           # Perform PCA.
           prep = ShogunPCA(s)

--- a/methods/shogun/perceptron.py
+++ b/methods/shogun/perceptron.py
@@ -60,7 +60,8 @@ class PERCEPTRON(object):
   def BuildModel(self, data, responses):
     # Create and train the classifier.
     model = Perceptron(RealFeatures(data.T), MulticlassLabels(responses))
-    model.set_max_iter(self.iterations)
+    if self.iterations:
+      model.set_max_iter(self.iterations)
     model.train()
     return model
 
@@ -87,8 +88,13 @@ class PERCEPTRON(object):
           X, y = SplitTrainData(self.dataset)
 
           # Gather all parameters.
-          s = re.search('-n (\d+)', options)
-          self.iterations = 1000 if not s else int(s.group(1))
+          self.iterations = None
+          if "max_iterations" in options:
+            self.iterations = int(options.pop("max_iterations"))
+
+          if len(options) > 0:
+            Log.Fatal("Unknown parameters: " + str(options))
+            raise Exception("unknown parameters")
 
           with totalTimer:
             # Perform perceptron classification.

--- a/methods/shogun/qda.py
+++ b/methods/shogun/qda.py
@@ -68,6 +68,10 @@ class QDA(object):
           testSet = np.genfromtxt(self.dataset[1], delimiter=',')
           testFeat = modshogun.RealFeatures(testData.T)
 
+        if len(options) > 0:
+          Log.Fatal("Unknown parameters: " + str(options))
+          raise Exception("unknown parameters")
+
         # Labels are the last row of the training set.
         labels = modshogun.MulticlassLabels(trainData[:, (trainData.shape[1] - 1)])
 

--- a/methods/shogun/random_forest.py
+++ b/methods/shogun/random_forest.py
@@ -79,13 +79,19 @@ class RANDOMFOREST(object):
       labels = MulticlassLabels(labels)
       testData = RealFeatures(LoadDataset(self.dataset[1]).T)
 
-      # Number of Trees.
-      n = re.search("-n (\d+)", options)
-      # Number of attributes to be chosen randomly to select from.
-      f = re.search("-f (\d+)", options)
+      if "num_trees" in options:
+        self.numTrees = int(options.pop("num_trees"))
+      else:
+        Log.Fatal("Required parameter 'num_trees' not specified!")
+        raise Exception("missing parameter")
 
-      self.form = 1 if not f else int(f.group(1))
-      self.numTrees = 10 if not n else int(n.group(1))
+      self.form = 1
+      if "dimensions" in options:
+        self.form = int(options.pop("dimensions"))
+
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
 
       try:
         with totalTimer:

--- a/methods/shogun/svr.py
+++ b/methods/shogun/svr.py
@@ -61,14 +61,19 @@ class SVR(object):
       X, y = SplitTrainData(self.dataset)
 
       # Get all the parameters.
-      c = re.search("-c (\d+\.\d+)", options)
-      e = re.search("-e (\d+\.\d+)", options)
-      g = re.search("-g (\d+\.\d+)", options)
+      self.C = 1.0
+      self.epsilon = 1.0
+      self.width = 0.1
+      if "c" in options:
+        self.C = float(options.pop("c"))
+      if "epsilon" in options:
+        self.epsilon = float(options.pop("epsilon"))
+      if "gamma" in options:
+        self.width = np.true_divide(1, float(options.pop("gamma")))
 
-      self.C = 1.0 if not c else float(c.group(1))
-      self.epsilon = 1.0 if not e else float(e.group(1))
-      g = 10.0 if not g else float(g.group(1))
-      self.width = np.true_divide(1, g)
+      if len(options) > 0:
+        Log.Fatal("Unknown parameters: " + str(options))
+        raise Exception("unknown parameters")
 
       data = RealFeatures(X.T)
       labels_train = RegressionLabels(y)

--- a/methods/weka/allknn.py
+++ b/methods/weka/allknn.py
@@ -45,6 +45,26 @@ class ALLKNN(object):
     self.timeout = timeout
 
   '''
+  Turn an input dict of options into a string we can pass to the program.
+  '''
+  def OptionsToStr(self, options):
+    optionsStr = ""
+    if "k" in options:
+      optionsStr = "-k " + str(options.pop("k"))
+    else:
+      Log.Fatal("Required parameter 'k' not specified!")
+      raise Exception("missing parameter")
+
+    if "seed" in options:
+      optionsStr = optionsStr + " -s " + str(options.pop("seed"))
+
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
+    return optionsStr
+
+  '''
   All K-Nearest-Neighbors. If the method has been successfully completed return
   the elapsed time in seconds.
 
@@ -59,13 +79,14 @@ class ALLKNN(object):
     # In this case we add this to the command line.
     if len(self.dataset) == 2:
       inputCmd = "-r " + self.dataset[0] + " -q " + self.dataset[1] + " " + \
-          options
+          self.OptionsToStr(options)
     else:
-      inputCmd = "-r " + self.dataset + " " + options
+      inputCmd = "-r " + self.dataset + " " + self.OptionsToStr(options)
 
     # Split the command using shell-like syntax.
     cmd = shlex.split("java -classpath " + self.path + "/weka.jar" +
-        ":methods/weka" + " AllKnn " + inputCmd + " " + options)
+        ":methods/weka" + " AllKnn " + inputCmd + " " +
+        self.OptionsToStr(options))
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/weka/allknn.py
+++ b/methods/weka/allknn.py
@@ -77,16 +77,16 @@ class ALLKNN(object):
 
     # If the dataset contains two files then the second file is the query file.
     # In this case we add this to the command line.
+    optionsStr = self.OptionsToStr(options)
     if len(self.dataset) == 2:
       inputCmd = "-r " + self.dataset[0] + " -q " + self.dataset[1] + " " + \
-          self.OptionsToStr(options)
+          optionsStr
     else:
-      inputCmd = "-r " + self.dataset + " " + self.OptionsToStr(options)
+      inputCmd = "-r " + self.dataset + " " + optionsStr
 
     # Split the command using shell-like syntax.
     cmd = shlex.split("java -classpath " + self.path + "/weka.jar" +
-        ":methods/weka" + " AllKnn " + inputCmd + " " +
-        self.OptionsToStr(options))
+        ":methods/weka" + " AllKnn " + inputCmd + " " + optionsStr)
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/weka/kmeans.py
+++ b/methods/weka/kmeans.py
@@ -45,6 +45,23 @@ class KMEANS(object):
     self.timeout = timeout
 
   '''
+  Given an input dict of options, convert them to strings.
+  '''
+  def OptionsToStr(self, options):
+    optionsStr = ""
+    if "clusters" in options:
+      optionsStr = "-c " + str(options.pop("clusters"))
+    else:
+      Log.Fatal("Required parameter 'clusters' not specified!")
+      raise Exception("missing parameter")
+
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameter")
+
+    return optionsStr
+
+  '''
   K-Means Clustering benchmark instance. If the method has been successfully
   completed return the elapsed time in seconds.
 
@@ -57,7 +74,8 @@ class KMEANS(object):
 
     # Split the command using shell-like syntax.
     cmd = shlex.split("java -classpath " + self.path +
-        "/weka.jar:methods/weka KMeans -i " + self.dataset[0] + " " + options)
+        "/weka.jar:methods/weka KMeans -i " + self.dataset[0] + " " +
+        self.OptionsToStr(options))
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/weka/linear_regression.py
+++ b/methods/weka/linear_regression.py
@@ -75,16 +75,20 @@ class LinearRegression(object):
   def RunMetrics(self, options):
     Log.Info("Perform Linear Regression.", self.verbose)
 
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
     # Load input dataset.
     # If the dataset contains two files then the second file is the responses
     # file. In this case we add this to the command line.
     if len(self.dataset) >= 2:
       cmd = shlex.split("java -classpath " + self.path + "/weka.jar" +
         ":methods/weka" + " LinearRegression -i " + self.dataset[0] + " -t " +
-        self.dataset[1] + " " + options)
+        self.dataset[1])
     else:
       cmd = shlex.split("java -classpath " + self.path + ":methods/weka" +
-        " LinearRegression -i " + self.dataset + " " + options)
+        " LinearRegression -i " + self.dataset)
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/weka/logistic_regression.py
+++ b/methods/weka/logistic_regression.py
@@ -75,16 +75,20 @@ class LogisticRegression(object):
   def RunMetrics(self, options):
     Log.Info("Perform Logistic Regression.", self.verbose)
 
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
     # Load input dataset.
     # If the dataset contains two files then the second file is the responses
     # file. In this case we add this to the command line.
     if len(self.dataset) >= 2:
       cmd = shlex.split("java -classpath " + self.path + "/weka.jar" +
         ":methods/weka LogisticRegression -i " + self.dataset[0] + " -t " +
-        self.dataset[1] + " " + options)
+        self.dataset[1])
     else:
       cmd = shlex.split("java -classpath " + self.path + ":methods/weka" +
-        " LogisticRegression -i " + self.dataset + " " + options)
+        " LogisticRegression -i " + self.dataset)
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/weka/nbc.py
+++ b/methods/weka/nbc.py
@@ -64,6 +64,10 @@ class NBC(object):
   def RunMetrics(self, options):
     Log.Info("Perform NBC.", self.verbose)
 
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
     if len(self.dataset) < 2:
       Log.Fatal("This method requires two or more datasets.")
       return -1
@@ -71,7 +75,7 @@ class NBC(object):
     # Split the command using shell-like syntax.
     cmd = shlex.split("java -classpath " + self.path + "/weka.jar" +
         ":methods/weka" + " NBC -t " + self.dataset[0] + " -T " +
-        self.dataset[1] + " " + options)
+        self.dataset[1])
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/methods/weka/pca.py
+++ b/methods/weka/pca.py
@@ -45,6 +45,24 @@ class PCA(object):
     self.timeout = timeout
 
   '''
+  Given an input dict of options, return a string that can be given to the
+  program.
+  '''
+  def OptionsToStr(self, options):
+    optionsStr = ""
+    if "new_dimensionality" in options:
+      optionsStr = "-d " + str(options.pop("new_dimensionality"))
+    if "whiten" in options:
+      optionsStr = optionsStr + " -s"
+      options.pop("whiten")
+
+    if len(options) > 0:
+      Log.Fatal("Unknown parameters: " + str(options))
+      raise Exception("unknown parameters")
+
+    return optionsStr
+
+  '''
   Perform Principal Components Analysis. If the method has been successfully 
   completed return the elapsed time in seconds.
 
@@ -57,7 +75,8 @@ class PCA(object):
 
     # Split the command using shell-like syntax.
     cmd = shlex.split("java -classpath " + self.path + "/weka.jar" +
-        ":methods/weka" + " PCA -i " + self.dataset + " " + options)
+        ":methods/weka" + " PCA -i " + self.dataset + " " +
+        self.OptionsToStr(options))
 
     # Run command with the nessecary arguments and return its output as a byte
     # string. We have untrusted input so we disable all shell based features.

--- a/small_config.yaml
+++ b/small_config.yaml
@@ -17,7 +17,10 @@ methods:
         format: [csv, txt]
         datasets:
             - files: ['None']
-              options: '--input_size=50000 --hidden_size=5000 --output_size=100'
+              options:
+                input_size: 50000
+                hidden_size: 5000
+                output_size: 100
 
     MLP_BACKWARD:
         run: ['metric']
@@ -26,4 +29,7 @@ methods:
         format: [csv, txt]
         datasets:
             - files: ['None']
-              options: '--input_size=50000 --hidden_size=5000 --output_size=100'
+              options:
+                input_size: 50000
+                hidden_size: 5000
+                output_size: 100

--- a/tests/benchmark_allkfn.py
+++ b/tests/benchmark_allkfn.py
@@ -49,7 +49,7 @@ class ALLKFN_MLPACK_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-k 3")
+    result = self.instance.RunMetrics({ "k": 3 })
     self.assertTrue(result["ComputingNeighbors"] > 0)
     self.assertTrue(result["Runtime"] > 0)
     self.assertTrue(result["TreeBuilding"] > 0)

--- a/tests/benchmark_allknn.py
+++ b/tests/benchmark_allknn.py
@@ -49,7 +49,7 @@ class ALLKNN_MLPACK_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-k 3")
+    result = self.instance.RunMetrics({ "k": 3 })
     self.assertTrue(result["ComputingNeighbors"] > 0)
     self.assertTrue(result["Runtime"] > 0)
     self.assertTrue(result["TreeBuilding"] > 0)
@@ -99,7 +99,7 @@ class ALLKNN_MATLAB_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-k 3")
+    result = self.instance.RunMetrics({ "k": 3 })
     self.assertTrue(result["Runtime"] > 0)
 
 '''
@@ -131,7 +131,7 @@ class ALLKNN_MLPY_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-k 3")
+    result = self.instance.RunMetrics({ "k": 3 })
     self.assertTrue(result["Runtime"] > 0)
 
 '''
@@ -163,7 +163,7 @@ class ALLKNN_SCIKIT_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-k 3")
+    result = self.instance.RunMetrics({ "k": 3 })
     print(result)
     self.assertTrue(result["Runtime"] > 0)
 
@@ -196,7 +196,7 @@ class ALLKNN_SHOGUN_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-k 3")
+    result = self.instance.RunMetrics({ "k": 3 })
     self.assertTrue(result["Runtime"] > 0)
 
 '''
@@ -228,7 +228,7 @@ class ALLKNN_WEKA_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-k 3")
+    result = self.instance.RunMetrics({ "k": 3 })
     self.assertTrue(result["Runtime"] > 0)
 
 '''
@@ -260,7 +260,7 @@ class ALLKNN_ANN_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-k 3")
+    result = self.instance.RunMetrics({ "k": 3 })
     self.assertTrue(result["Runtime"] > 0)
     self.assertTrue(result["ComputingNeighbors"] > 0)
     self.assertTrue(result["TreeBuilding"] > 0)
@@ -294,7 +294,7 @@ class ALLKNN_FLANN_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-k 3")
+    result = self.instance.RunMetrics({ "k": 3 })
     self.assertTrue(result["TreeBuilding"] > 0)
     self.assertTrue(result["Runtime"] > 0)
     self.assertTrue(result["ComputingNeighbors"] > 0)

--- a/tests/benchmark_allkrann.py
+++ b/tests/benchmark_allkrann.py
@@ -49,7 +49,7 @@ class ALLKRANN_MLPACK_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-k 3 -T 10")
+    result = self.instance.RunMetrics({ "k": 3, "tau": 10 })
     self.assertTrue(result["ComputingNeighbors"] > 0)
     self.assertTrue(result["Runtime"] > 0)
     self.assertTrue(result["TreeBuilding"] > 0)

--- a/tests/benchmark_ann.py
+++ b/tests/benchmark_ann.py
@@ -46,7 +46,7 @@ class ANN_ANNOY_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-k 10 -n 10")
+    result = self.instance.RunMetrics({ "k": 10, "num_trees": 10 })
     self.assertTrue(result["Runtime"] > 0)
 
 class ANN_MRPT_TEST(unittest.TestCase):
@@ -74,7 +74,7 @@ class ANN_MRPT_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-k 5 -n 5")
+    result = self.instance.RunMetrics({ "k": 5, "num_trees": 5 })
     self.assertTrue(result["Runtime"] > 0)
 
 class ANN_SCIKIT_TEST(unittest.TestCase):
@@ -102,7 +102,7 @@ class ANN_SCIKIT_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-k 5 -n 5")
+    result = self.instance.RunMetrics({ "k": 5, "num_trees": 5 })
     self.assertTrue(result["Runtime"] > 0)
 
 

--- a/tests/benchmark_decision_stump.py
+++ b/tests/benchmark_decision_stump.py
@@ -45,7 +45,7 @@ class DecisionStump_MLPACK_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
     
 if __name__ == '__main__':

--- a/tests/benchmark_decision_tree.py
+++ b/tests/benchmark_decision_tree.py
@@ -82,9 +82,6 @@ class DecisionTree_SHOGUN_TEST(unittest.TestCase):
     result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
-if __name__ == '__main__':
-  unittest.main()
-
 '''
 Test the milk Decision Tree Prediction script.
 '''
@@ -117,3 +114,5 @@ class DecisionTree_Milk_TEST(unittest.TestCase):
     result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/benchmark_decision_tree.py
+++ b/tests/benchmark_decision_tree.py
@@ -47,7 +47,7 @@ class DecisionTree_SCIKIT_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
 '''
@@ -79,7 +79,7 @@ class DecisionTree_SHOGUN_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
 if __name__ == '__main__':
@@ -114,6 +114,6 @@ class DecisionTree_Milk_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 

--- a/tests/benchmark_det.py
+++ b/tests/benchmark_det.py
@@ -49,7 +49,7 @@ class DET_MLPACK_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Training"] > 0)
     self.assertTrue(result["Runtime"] > 0)
 

--- a/tests/benchmark_emst.py
+++ b/tests/benchmark_emst.py
@@ -49,7 +49,7 @@ class EMST_MLPACK_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
     self.assertTrue(result["TreeBuilding"] > 0)
 

--- a/tests/benchmark_fastmks.py
+++ b/tests/benchmark_fastmks.py
@@ -49,7 +49,7 @@ class FASTMKS_MLPACK_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics({ "k": 1 })
+    result = self.instance.RunMetrics({ "k": 1, "kernel": "linear" })
     self.assertTrue(result["Runtime"] > 0)
     self.assertTrue(result["TreeBuilding"] > 0)
 

--- a/tests/benchmark_fastmks.py
+++ b/tests/benchmark_fastmks.py
@@ -49,7 +49,7 @@ class FASTMKS_MLPACK_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-k 1")
+    result = self.instance.RunMetrics({ "k": 1 })
     self.assertTrue(result["Runtime"] > 0)
     self.assertTrue(result["TreeBuilding"] > 0)
 

--- a/tests/benchmark_gmm.py
+++ b/tests/benchmark_gmm.py
@@ -47,7 +47,7 @@ class GMM_SHOGUN_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
 '''
@@ -80,7 +80,7 @@ class GMM_SCIKIT_TEST(unittest.TestCase):
   '''
   def test_RunMetrics(self):
     print("asdw")
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     print("result" + str(result))
     # self.assertTrue(result > 0)
 

--- a/tests/benchmark_gmm.py
+++ b/tests/benchmark_gmm.py
@@ -47,7 +47,7 @@ class GMM_SHOGUN_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics({})
+    result = self.instance.RunMetrics({ "gaussians": 5 })
     self.assertTrue(result["Runtime"] > 0)
 
 '''
@@ -79,9 +79,7 @@ class GMM_SCIKIT_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    print("asdw")
-    result = self.instance.RunMetrics({})
-    print("result" + str(result))
+    result = self.instance.RunMetrics({ "gaussians": 5 })
     # self.assertTrue(result > 0)
 
 if __name__ == '__main__':

--- a/tests/benchmark_gmm.py
+++ b/tests/benchmark_gmm.py
@@ -80,7 +80,7 @@ class GMM_SCIKIT_TEST(unittest.TestCase):
   '''
   def test_RunMetrics(self):
     result = self.instance.RunMetrics({ "gaussians": 5 })
-    # self.assertTrue(result > 0)
+    self.assertTrue(result["Runtime"] > 0)
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/benchmark_hmm_generate.py
+++ b/tests/benchmark_hmm_generate.py
@@ -35,7 +35,7 @@ class HMMGENERATE_MLPACK_TEST(unittest.TestCase):
     module = Loader.ImportModuleFromPath("methods/mlpack/hmm_train.py")
     obj = getattr(module, "HMMTRAIN")
     self.instance = obj(self.dataset, verbose=self.verbose, timeout=self.timeout)
-    result = self.instance.RunMetrics("-t gaussian -n 2 -o datasets/iris_hmm.xml")
+    result = self.instance.RunMetrics({ "type": "gaussian", "states": 2, "output": "datasets/iris_hmm.xml" })
 
     self.dataset = 'datasets/iris_hmm.xml'
     module = Loader.ImportModuleFromPath("methods/mlpack/hmm_generate.py")
@@ -56,7 +56,7 @@ class HMMGENERATE_MLPACK_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-l 1")
+    result = self.instance.RunMetrics({ "length": 1 })
     self.assertTrue(result["Runtime"] > 0)
 
   '''

--- a/tests/benchmark_hmm_loglik.py
+++ b/tests/benchmark_hmm_loglik.py
@@ -35,7 +35,7 @@ class HMMLOGLIK_MLPACK_TEST(unittest.TestCase):
     module = Loader.ImportModuleFromPath("methods/mlpack/hmm_train.py")
     obj = getattr(module, "HMMTRAIN")
     self.instance = obj(self.dataset, verbose=self.verbose, timeout=self.timeout)
-    result = self.instance.RunMetrics("-t gaussian -n 2 -o datasets/iris_hmm.xml")
+    result = self.instance.RunMetrics({ "type": "gaussian", "states": 2, "output": "datasets/iris_hmm.xml" })
 
     self.dataset = ['datasets/iris.csv', 'datasets/iris_hmm.xml']
     module = Loader.ImportModuleFromPath("methods/mlpack/hmm_loglik.py")
@@ -56,7 +56,7 @@ class HMMLOGLIK_MLPACK_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunTiming(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
   '''

--- a/tests/benchmark_hmm_train.py
+++ b/tests/benchmark_hmm_train.py
@@ -49,7 +49,7 @@ class HMMTRAIN_MLPACK_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-t gaussian -n 2")
+    result = self.instance.RunMetrics({ "type": "gaussian", "states": 2 })
     self.assertTrue(result["Runtime"] > 0)
 
   '''

--- a/tests/benchmark_hmm_viterbi.py
+++ b/tests/benchmark_hmm_viterbi.py
@@ -35,7 +35,8 @@ class HMMVITERBI_MLPACK_TEST(unittest.TestCase):
     module = Loader.ImportModuleFromPath("methods/mlpack/hmm_train.py")
     obj = getattr(module, "HMMTRAIN")
     self.instance = obj(self.dataset, verbose=self.verbose, timeout=self.timeout)
-    result = self.instance.RunMetrics("-t gaussian -n 2 -o datasets/iris_hmm.xml")
+    result = self.instance.RunMetrics({ "type": "gaussian", "states": 2,
+        "output": "datasets/iris_hmm.xml" })
 
     self.dataset = ['datasets/iris.csv', 'datasets/iris_hmm.xml']
     module = Loader.ImportModuleFromPath("methods/mlpack/hmm_viterbi.py")
@@ -56,7 +57,7 @@ class HMMVITERBI_MLPACK_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
   '''

--- a/tests/benchmark_ica.py
+++ b/tests/benchmark_ica.py
@@ -49,7 +49,7 @@ class ICA_MLPACK_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
   '''
@@ -95,7 +95,7 @@ class ICA_SCIKIT_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
 if __name__ == '__main__':

--- a/tests/benchmark_kernel_pca.py
+++ b/tests/benchmark_kernel_pca.py
@@ -49,7 +49,7 @@ class KPCA_MLPACK_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-k linear")
+    result = self.instance.RunMetrics({ "kernel": "linear" })
     self.assertTrue(result["Runtime"] > 0)
 
   '''
@@ -95,7 +95,7 @@ class KPCA_SCIKIT_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-k linear")
+    result = self.instance.RunMetrics({ "kernel": "linear" })
     self.assertTrue(result["Runtime"] > 0)
 
 '''
@@ -127,7 +127,7 @@ class KPCA_MLPY_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-k linear")
+    result = self.instance.RunMetrics({ "kernel": "linear" })
     self.assertTrue(result["Runtime"] > 0)
 
 '''
@@ -159,7 +159,7 @@ class KPCA_SHOGUN_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-k linear")
+    result = self.instance.RunMetrics({ "kernel": "linear" })
     self.assertTrue(result["Runtime"] > 0)
 
 if __name__ == '__main__':

--- a/tests/benchmark_kmeans.py
+++ b/tests/benchmark_kmeans.py
@@ -47,7 +47,7 @@ class KMEANS_MLPACK_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-c 3")
+    result = self.instance.RunMetrics({ "clusters": 3 })
     self.assertTrue(result["Runtime"] > 0)
 
   '''
@@ -93,7 +93,7 @@ class KMEANS_MLPY_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-c 3")
+    result = self.instance.RunMetrics({ "clusters": 3 })
     self.assertTrue(result["Runtime"] > 0)
 
 '''
@@ -125,7 +125,7 @@ class KMEANS_WEKA_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-c 3")
+    result = self.instance.RunMetrics({ "clusters": 3 })
     self.assertTrue(result["Runtime"] > 0)
 
 '''
@@ -157,7 +157,7 @@ class KMEANS_MATLAB_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-c 3")
+    result = self.instance.RunMetrics({ "clusters": 3 })
     self.assertTrue(result["Runtime"] > 0)
 
 if __name__ == '__main__':
@@ -192,6 +192,6 @@ class KMEANS_MILK_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-c 3")
+    result = self.instance.RunMetrics({ "clusters": 3 })
     self.assertTrue(result["Runtime"] > 0)
 

--- a/tests/benchmark_kmeans.py
+++ b/tests/benchmark_kmeans.py
@@ -160,9 +160,6 @@ class KMEANS_MATLAB_TEST(unittest.TestCase):
     result = self.instance.RunMetrics({ "clusters": 3 })
     self.assertTrue(result["Runtime"] > 0)
 
-if __name__ == '__main__':
-  unittest.main()
-
 '''
 Test the milk K-Means clustering script.
 '''
@@ -195,3 +192,5 @@ class KMEANS_MILK_TEST(unittest.TestCase):
     result = self.instance.RunMetrics({ "clusters": 3 })
     self.assertTrue(result["Runtime"] > 0)
 
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/benchmark_lars.py
+++ b/tests/benchmark_lars.py
@@ -49,7 +49,7 @@ class LARS_MLPACK_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
   '''
@@ -95,7 +95,7 @@ class LARS_SHOGUN_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
 '''
@@ -127,7 +127,7 @@ class LARS_SCIKIT_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
 if __name__ == '__main__':

--- a/tests/benchmark_lasso.py
+++ b/tests/benchmark_lasso.py
@@ -46,7 +46,7 @@ class LASSO_SHOGUN_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
 '''
@@ -78,7 +78,7 @@ class LASSO_SCIKIT_TEST(unittest.TestCase):
   Test the 'RunTiming' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
 

--- a/tests/benchmark_linear_regression.py
+++ b/tests/benchmark_linear_regression.py
@@ -49,7 +49,7 @@ class LinearRegression_MLPACK_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
   '''
@@ -120,7 +120,7 @@ class LinearRegression_SHOGUN_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
 '''
@@ -152,7 +152,7 @@ class LinearRegression_SCIKIT_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
 '''
@@ -184,7 +184,7 @@ class LinearRegression_MLPY_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     print(result)
     self.assertTrue(result["Runtime"] > 0)
 
@@ -217,7 +217,7 @@ class LinearRegression_MATLAB_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
 if __name__ == '__main__':

--- a/tests/benchmark_linear_ridge_regression.py
+++ b/tests/benchmark_linear_ridge_regression.py
@@ -47,7 +47,7 @@ class LinearRidgeRegression_SHOGUN_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-t 1.0")
+    result = self.instance.RunMetrics({ "alpha": 1.0 })
     self.assertTrue(result["Simple MSE"] > 0)
     self.assertTrue(result["Runtime"] > 0)
 
@@ -80,7 +80,7 @@ class LinearRidgeRegression_SCIKIT_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-t 1.0")
+    result = self.instance.RunMetrics({ "alpha": 1.0 })
     self.assertTrue(result["Runtime"] > 0)
     self.assertTrue(result["Simple MSE"] > 0)
 

--- a/tests/benchmark_local_coordinate_coding.py
+++ b/tests/benchmark_local_coordinate_coding.py
@@ -47,7 +47,7 @@ class LocalCoordinateCoding_MLPACK_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-k 2")
+    result = self.instance.RunMetrics({ "atoms": 2 })
     self.assertTrue(result["Runtime"] > 0)
 
   '''

--- a/tests/benchmark_logistic_regression.py
+++ b/tests/benchmark_logistic_regression.py
@@ -146,7 +146,7 @@ class lr_mlpack_test(unittest.TestCase):
   Test the RunMetrics() function.
   '''
   def testRunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result['Runtime'] > 0)
 
 if __name__ == '__main__':

--- a/tests/benchmark_logistic_regression.py
+++ b/tests/benchmark_logistic_regression.py
@@ -16,6 +16,7 @@ if cmd_subfolder not in sys.path:
   sys.path.insert(0, cmd_subfolder)
 
 from loader import *
+
 '''
 Test the Scikit Logistic Regression Classifier script.
 '''
@@ -81,9 +82,6 @@ class LR_SHOGUN_TEST(unittest.TestCase):
     self.assertTrue(result["Runtime"] > 0)
 
 
-if __name__ == '__main__':
-  unittest.main()
-
 '''
 Test the Milk Logistic Regression Classifier script.
 '''
@@ -116,6 +114,40 @@ class LR_Milk_TEST(unittest.TestCase):
     result = self.instance.RunMetrics("")
     self.assertTrue(result["Runtime"] > 0)
 
+'''
+Test the mlpack logistic regression classifier script.
+'''
+class lr_mlpack_test(unittest.TestCase):
+
+  '''
+  Initialization.
+  '''
+  def setUp(self):
+    self.dataset = ['datasets/ecoli_train.csv', 'datasets/ecoli_test.csv',
+        'datasets/ecoli_labels.csv']
+    self.verbose = False
+    self.timeout = 9000
+
+    module = \
+        Loader.ImportModuleFromPath("methods/mlpack/logistic_regression.py")
+    obj = getattr(module, "LogisticRegression")
+    self.instance = obj(self.dataset, verbose=self.verbose,
+        timeout=self.timeout)
+
+  '''
+  Test the constructor.
+  '''
+  def testConstructor(self):
+    self.assertEqual(self.instance.verbose, self.verbose)
+    self.assertEqual(self.instance.timeout, self.timeout)
+    self.assertEqual(self.instance.dataset, self.dataset)
+
+  '''
+  Test the RunMetrics() function.
+  '''
+  def testRunMetrics(self):
+    result = self.instance.RunMetrics("")
+    self.assertTrue(result['Runtime'] > 0)
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/benchmark_logistic_regression.py
+++ b/tests/benchmark_logistic_regression.py
@@ -46,7 +46,7 @@ class LR_SCIKIT_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
 '''
@@ -78,7 +78,7 @@ class LR_SHOGUN_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
 
@@ -111,7 +111,7 @@ class LR_Milk_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
 '''

--- a/tests/benchmark_lsh.py
+++ b/tests/benchmark_lsh.py
@@ -47,7 +47,7 @@ class LSH_MLPACK_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics({ "atoms": 2 })
+    result = self.instance.RunMetrics({ "k": 2 })
     self.assertTrue(result["Runtime"] > 0)
     self.assertTrue(result["HashBuilding"] > 0)
 

--- a/tests/benchmark_lsh.py
+++ b/tests/benchmark_lsh.py
@@ -47,7 +47,7 @@ class LSH_MLPACK_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-k 2")
+    result = self.instance.RunMetrics({ "atoms": 2 })
     self.assertTrue(result["Runtime"] > 0)
     self.assertTrue(result["HashBuilding"] > 0)
 

--- a/tests/benchmark_nbc.py
+++ b/tests/benchmark_nbc.py
@@ -47,7 +47,7 @@ class NBC_MLPACK_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Training"] > 0)
     self.assertTrue(result["Runtime"] > 0)
     self.assertTrue(result["Testing"] > 0)
@@ -95,7 +95,7 @@ class NBC_WEKA_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
 '''
@@ -127,7 +127,7 @@ class NBC_SHOGUN_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
 '''
@@ -159,7 +159,7 @@ class NBC_SCIKIT_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
     
 
@@ -192,7 +192,7 @@ class NBC_MATLAB_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
 if __name__ == '__main__':

--- a/tests/benchmark_nca.py
+++ b/tests/benchmark_nca.py
@@ -47,7 +47,7 @@ class NCA_MLPACK_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
   '''

--- a/tests/benchmark_nmf.py
+++ b/tests/benchmark_nmf.py
@@ -49,7 +49,7 @@ class NMF_MLPACK_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-r 6 -u multdist")
+    result = self.instance.RunMetrics({ "rank": 6, "update_rules": "multdist" })
     self.assertTrue(result["Runtime"] > 0)
 
   '''
@@ -95,7 +95,7 @@ class NMF_SCIKIT_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-r 6 -u alspgrad")
+    result = self.instance.RunMetrics({ "rank": 6 })
     self.assertTrue(result["Runtime"] > 0)
 
 '''
@@ -127,7 +127,7 @@ class NMF_MATLAB_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-r 6 -u multdist")
+    result = self.instance.RunMetrics({ "rank": 6, "update_rules": "multdist" })
     self.assertTrue(result["Runtime"] > 0)
 
 if __name__ == '__main__':

--- a/tests/benchmark_pca.py
+++ b/tests/benchmark_pca.py
@@ -49,7 +49,7 @@ class PCA_MLPACK_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
   '''
@@ -95,7 +95,7 @@ class PCA_WEKA_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
 '''
@@ -127,7 +127,7 @@ class PCA_SHOGUN_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
 '''
@@ -159,7 +159,7 @@ class PCA_SCIKIT_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
 '''
@@ -191,7 +191,7 @@ class PCA_MLPY_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
 '''
@@ -223,7 +223,7 @@ class PCA_MATLAB_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
 if __name__ == '__main__':

--- a/tests/benchmark_qda.py
+++ b/tests/benchmark_qda.py
@@ -47,7 +47,7 @@ class QDA_SHOGUN_TEST(unittest.TestCase):
   '''
   def test_RunMetrics(self):
     result = self.instance.RunMetrics({})
-    self.assertTrue(result > 0)
+    self.assertTrue(result["Runtime"] > 0)
 
 '''
 Test the scikit QDA script.
@@ -78,8 +78,8 @@ class QDA_SCIKIT_TEST(unittest.TestCase):
   Test the 'RunTiming' function.
   '''
   def test_RunTiming(self):
-    result = self.instance.RunTiming("")
-    self.assertTrue(result > 0)
+    result = self.instance.RunMetrics({})
+    self.assertTrue(result["Runtime"] > 0)
 
 
 if __name__ == '__main__':

--- a/tests/benchmark_qda.py
+++ b/tests/benchmark_qda.py
@@ -46,7 +46,7 @@ class QDA_SHOGUN_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result > 0)
 
 '''

--- a/tests/benchmark_random_forest.py
+++ b/tests/benchmark_random_forest.py
@@ -46,7 +46,7 @@ class RandomForest_SCIKIT_TEST(unittest.TestCase):
   Test the RunMetrics Function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({ "num_trees": 10 })
     self.assertTrue(result["Runtime"] > 0)
 
 '''
@@ -79,7 +79,7 @@ class RandomForest_SHOGUN_TEST(unittest.TestCase):
   Test the RunMetrics Function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({ "num_trees": 10 })
     self.assertTrue(result["Runtime"] > 0)
 
 
@@ -115,6 +115,6 @@ class RandomForest_Milk_TEST(unittest.TestCase):
   Test the RunMetrics Function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({ "num_trees": 10 })
     self.assertTrue(result["Runtime"] > 0)
 

--- a/tests/benchmark_random_forest.py
+++ b/tests/benchmark_random_forest.py
@@ -82,9 +82,6 @@ class RandomForest_SHOGUN_TEST(unittest.TestCase):
     result = self.instance.RunMetrics({ "num_trees": 10 })
     self.assertTrue(result["Runtime"] > 0)
 
-
-if __name__ == '__main__':
-  unittest.main()
 '''
 Test the Milk RandomForest script.
 '''
@@ -118,3 +115,5 @@ class RandomForest_Milk_TEST(unittest.TestCase):
     result = self.instance.RunMetrics({ "num_trees": 10 })
     self.assertTrue(result["Runtime"] > 0)
 
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/benchmark_range_search.py
+++ b/tests/benchmark_range_search.py
@@ -49,7 +49,7 @@ class RANGESEARCH_MLPACK_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-M 0.02")
+    result = self.instance.RunMetrics({ "max": 0.02 })
     self.assertTrue(result["Runtime"] > 0)
 
   '''
@@ -95,7 +95,7 @@ class RANGESEARCH_MATLAB_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-M 0.02")
+    result = self.instance.RunMetrics({ "max": 0.02 })
     self.assertTrue(result["Runtime"] > 0)
 
 if __name__ == '__main__':

--- a/tests/benchmark_sparse_coding.py
+++ b/tests/benchmark_sparse_coding.py
@@ -49,7 +49,7 @@ class SparseCoding_MLPACK_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("-k 2")
+    result = self.instance.RunMetrics({ "atoms": 2 })
     self.assertTrue(result["Runtime"] > 0)
 
   '''

--- a/tests/benchmark_svr.py
+++ b/tests/benchmark_svr.py
@@ -47,7 +47,7 @@ class SVR_SHOGUN_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     self.assertTrue(result["Runtime"] > 0)
 
 '''
@@ -79,7 +79,7 @@ class SVR_SCIKIT_TEST(unittest.TestCase):
   Test the 'RunMetrics' function.
   '''
   def test_RunMetrics(self):
-    result = self.instance.RunMetrics("")
+    result = self.instance.RunMetrics({})
     print(result)
     self.assertTrue(result["Runtime"] > 0)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -30,6 +30,7 @@ modules = [
 'benchmark_nca',
 'benchmark_nmf',
 'benchmark_pca',
+'benchmark_qda',
 'benchmark_random_forest',
 'benchmark_range_search',
 'benchmark_sparse_coding',


### PR DESCRIPTION
This is still a bit of a work in progress as I figure out the small bugs in the tests and everything, but I wanted to post it quickly for review since it's a pretty major change and could affect the work @Iron-Stark is doing (depending).  Basically, there are two major changes:

* options are now represented as dicts

So in a config file, instead of `options: '-c 2'` you would have

```
options:
  clusters: 2
```

and so forth.  The majority of these changes go to support this change.  I had to re-adapt every method's benchmarking script.  In many cases, I found some parameters that weren't ever being passed on to the method being benchmarking, so I just removed them.  In other cases, I found that defaults were being manually encoded into the benchmarking scripts, but I think it is better to specify nothing at all (where possible) and therefore use the library's defaults.  All of the tests also had to be adapted (slightly).

* sweep support for parameters

Now you can specify

```
options:
  max_iterations: sweep(10, 10, 100)
```

and the benchmarking system will run with `max_iterations = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]`.  This involved adding an extra `sweeps` table to the results, and then adding a `sweep_id` and `sweep_elem_id` to every run.  `sweep_id` is `-1` if there is no sweep happening; otherwise the `sweep_id` is set to the id of the corresponding sweep in the `sweeps` table.  Sweeps can have type `int` or `float`.

There are no visualizations yet that use the sweep types---I will have to work on those next.

I expect to keep pushing to this branch in the next day as I work out all the failing tests.