### PR TITLE
Add sweep displays

### DIFF
--- a/reports/css/d3-style.css
+++ b/reports/css/d3-style.css
@@ -157,7 +157,7 @@ svg text {
 }
 
 .method-select-label, .param-select-label, .main-dataset-select-label,
-.sweep-select-label {
+.sweep-select-label, .metric-select-label {
   float: left;
   font-size: 75%;
   color: #ffffff;

--- a/reports/css/d3-style.css
+++ b/reports/css/d3-style.css
@@ -156,14 +156,15 @@ svg text {
   padding: 10px;
 }
 
-.method-select-label, .param-select-label, .main-dataset-select-label {
+.method-select-label, .param-select-label, .main-dataset-select-label,
+.sweep-select-label {
   float: left;
   font-size: 75%;
   color: #ffffff;
   margin-right: 8px;
 }
 
-#method_select, #param_select, #main_dataset_select,
+#method_select, #param_select, #sweep_select, #main_dataset_select,
 #metric_select, #option_select {
   float: left;
   margin-right: 20px;

--- a/reports/index.html
+++ b/reports/index.html
@@ -50,6 +50,11 @@ onclick="chartTypeSelect()">
       <label for="chart-type-radio-7" class="chart-type-radio-label">Runtime
 plots for parameter sweeps</label>
     </div>
+    <div>
+      <input class="chart-type-radio" type="radio" name="chart-type" value="sweep-metric-comparison" id="chart-type-radio-8" onclick="chartTypeSelect()">
+      <label for="chart-type-radio-8" class="chart-type-radio-label">Metric
+plots for parameter sweeps</label>
+    </div>
 
     <div class="selectholder" id="selectholder"></div>
     <div class="clear"></div>
@@ -74,5 +79,6 @@ plots for parameter sweeps</label>
   <script src='js/benchmarks/highest_metric-comparison-view.js'></script>
   <script src='js/benchmarks/metric-multiple-parameter-comparison-view.js'></script>
   <script src='js/benchmarks/sweep-comparison-view.js'></script>
+  <script src='js/benchmarks/sweep-metric-comparison-view.js'></script>
 </body>
 </html>

--- a/reports/index.html
+++ b/reports/index.html
@@ -43,7 +43,13 @@
       <input class="chart-type-radio" type="radio" name="chart-type" value="metric-multiple-parameter-comparison" id="chart-type-radio-6" onclick="chartTypeSelect()">
       <label for="chart-type-radio-6" class="chart-type-radio-label">Metric analysis with multiple parameters for an algorithm/dataset combination</label>
     </div>
-
+    <div>
+      <input class="chart-type-radio" type="radio" name="chart-type"
+value="sweep-runtime-comparison" id="chart-type-radio-7"
+onclick="chartTypeSelect()">
+      <label for="chart-type-radio-7" class="chart-type-radio-label">Runtime
+plots for parameter sweeps</label>
+    </div>
 
     <div class="selectholder" id="selectholder"></div>
     <div class="clear"></div>
@@ -67,5 +73,6 @@
   <script src='js/benchmarks/metric-comparison-view.js'></script>
   <script src='js/benchmarks/highest_metric-comparison-view.js'></script>
   <script src='js/benchmarks/metric-multiple-parameter-comparison-view.js'></script>
+  <script src='js/benchmarks/sweep-comparison-view.js'></script>
 </body>
 </html>

--- a/reports/js/benchmarks.js
+++ b/reports/js/benchmarks.js
@@ -140,6 +140,7 @@ function chartTypeSelect()
   else if (chartType == "dataset-comparison") { activeChartType = dc; }
   else if (chartType == "metric-comparison") { activeChartType = mc; }
   else if (chartType == "highest-metric-comparison") { activeChartType = hmc; }
+  else if (chartType == "sweep-runtime-comparison") { activeChartType = sc; }
 
   activeChartType.onTypeSelect();
 }

--- a/reports/js/benchmarks.js
+++ b/reports/js/benchmarks.js
@@ -141,6 +141,7 @@ function chartTypeSelect()
   else if (chartType == "metric-comparison") { activeChartType = mc; }
   else if (chartType == "highest-metric-comparison") { activeChartType = hmc; }
   else if (chartType == "sweep-runtime-comparison") { activeChartType = sc; }
+  else if (chartType == "sweep-metric-comparison") { activeChartType = smc; }
 
   activeChartType.onTypeSelect();
 }

--- a/reports/js/benchmarks/historical-comparison-view.js
+++ b/reports/js/benchmarks/historical-comparison-view.js
@@ -100,7 +100,7 @@ hc.paramSelect = function()
   var param_select_box = document.getElementById("param_select");
   var param_name_full = param_select_box.options[param_select_box.selectedIndex].text;
   // Parse out actual parameters.
-  hc.param_name = param_name_full.split("(")[0].replace(/^\s+|\s+$/g, ''); // At higher scope.
+  hc.param_name = param_name_full.split("(").slice(0, -1).join("(").replace(/^\s+|\s+$/g, ''); // At higher scope.
   if (hc.param_name == "[no parameters]") { hc.param_name = ""; }
 
   // Given a method name and parameters, query the SQLite database for all of

--- a/reports/js/benchmarks/metric-multiple-parameter-comparison-view.js
+++ b/reports/js/benchmarks/metric-multiple-parameter-comparison-view.js
@@ -97,11 +97,13 @@ mmpc.listOptions = function()
                  "AND methods.name = '" + mmpc.method_name + "' " +
                  "AND datasets.name = '" + mmpc.dataset_name + "';";
   var results = dbExec(sqlstr);
+  console.log(JSON.stringify(results));
   results = dbType === "sqlite" ? results[0].values : results;
 
   var addOption = function(p, c) {
     var options = mmpc.getOptionList(dbType === "sqlite" ? c.toString() : c.parameter);
 
+    console.log(JSON.stringify(options));
     for (i = 0; i < options.length; i++)
       if(p.indexOf(options[i]) < 0) p.push(options[i]);
     return p;
@@ -131,6 +133,7 @@ mmpc.listMetrics = function()
                  "AND datasets.name = '" + mmpc.dataset_name + "';";
   var results = dbExec(sqlstr);
   results = dbType === "sqlite" ? results[0].values : results;
+  console.log(results);
 
   addMetric = function(p, c) {
     var json = jQuery.parseJSON(dbType === "sqlite" ? c : c.metric);
@@ -198,9 +201,10 @@ mmpc.metricSelect = function()
                  "AND methods.name = '" + mmpc.method_name + "' " +
                  "AND datasets.name = '" + mmpc.dataset_name + "';";
   mmpc.results = dbExec(sqlstr);
+  console.log(sqlstr);
   mmpc.results = dbType === "sqlite" ? mmpc.results[0].values : mmpc.results;
 
-  console.log(mmpc.results)
+  console.log(JSON.stringify(mmpc.results));
 
   var filterAndSet = function(p, d) {
     var metrics = jQuery.parseJSON(dbType === "sqlite" ? d[0] : d.metric);
@@ -358,13 +362,15 @@ mmpc.clearChart = function()
 // Return a param's value from a list of parameters.
 mmpc.getOptionValue = function(str, opt)
 {
-  var list = str.split("-" + opt)
-  if (list.length < 2)
-    return "";
-  list = list[1].split(/[\s=]+/);
-  if (list.length < 2)
-    return "";
-  return list[1];
+  var options = JSON.parse(str);
+  console.log("getOptionValue: " + str);
+  if (opt in options)
+  {
+    // Then we know the value.
+    return options[opt];
+  }
+  
+  return "";
 }
 
 // Remove a parameter from the list of parameters.
@@ -376,11 +382,12 @@ mmpc.removeOption = function(str, opt)
 // Returns a list of parameters.
 mmpc.getOptionList = function(str)
 {
-  optList = str.split(/-+/)
-      .map(function (d) {return d.replace(/^\s+|\s+$/g, '').split(/[\s=]+/); })
-      .filter(function (d) {return (d.length >= 1);})
-      .map(function (d) {return d[0];});
-  optList.shift();
+  var opts = JSON.parse(str);
+  var optList = [];
+  for (var k in opts)
+  {
+    optList.push(k);
+  }
   return optList;
 }
 

--- a/reports/js/benchmarks/metric-parameter-comparison-view.js
+++ b/reports/js/benchmarks/metric-parameter-comparison-view.js
@@ -113,7 +113,7 @@ mpc.paramSelect = function()
   var param_select_box = document.getElementById("param_select");
   var param_name_full = param_select_box.options[param_select_box.selectedIndex].text;
   // Parse out actual parameters.
-  mpc.param_name = param_name_full.split("(")[0].replace(/^\s+|\s+$/g, ''); // At higher scope.
+  mpc.param_name = param_name_full.split("(").slice(0, -1).join("(").replace(/^\s+|\s+$/g, ''); // At higher scope.
   if (mpc.param_name == "[no parameters]") { mpc.param_name = ""; }
 
   if (mpc.param_name == "-")

--- a/reports/js/benchmarks/runtime-comparison-view.js
+++ b/reports/js/benchmarks/runtime-comparison-view.js
@@ -210,7 +210,7 @@ rc.paramSelect = function()
     var step = func(dbType === "sqlite" ? rc.results[0][2] : rc.results[0].step);
     var end = func(dbType === "sqlite" ? rc.results[0][3] : rc.results[0].end);
     var elem = 0;
-    for (var i = start; i < end; i += step, elem++)
+    for (var i = start; i <= end; i += step, elem++)
     {
       var new_option = document.createElement("option");
       new_option.text = name + ": " + i;

--- a/reports/js/benchmarks/sweep-comparison-view.js
+++ b/reports/js/benchmarks/sweep-comparison-view.js
@@ -219,6 +219,10 @@ sc.datasetSelect = function()
 sc.clearChart = function()
 {
   d3.select("svg").remove();
+  d3.selectAll(".d3-tip").remove();
+  d3.selectAll(".library-select-title").remove();
+  d3.selectAll(".library_select_div").remove();
+  d3.selectAll(".legendholder").selectAll("*").remove();
 }
 
 sc.buildChart = function()

--- a/reports/js/benchmarks/sweep-comparison-view.js
+++ b/reports/js/benchmarks/sweep-comparison-view.js
@@ -1,12 +1,13 @@
 // Define namespace: sc = sweep comparison.
 var sc = sc = sc || {};
 
-sc.method_name = "";
-sc.param_name = "";
+sc.methodName = "";
+sc.paramName = "";
 sc.dataset = "";
 sc.libraries = [];
-sc.active_libraries = [];
+sc.activeLibraries = [];
 sc.results = [];
+sc.sweepId = -1;
 
 // This chart type has been selected.
 sc.onTypeSelect = function()
@@ -74,7 +75,7 @@ sc.methodSelect = function()
 
   var sqlstr = "SELECT DISTINCT methods.parameters, methods.sweep_id, " +
       "metrics.libary_id, COUNT(DISTINCT metrics.libary_id) AS count FROM " +
-      "methods, metrics WHERE methods.name = '" + sc.method_name +
+      "methods, metrics WHERE methods.name = '" + sc.methodName +
       "' AND methods.id = metrics.method_id AND methods.sweep_id != -1 " +
       "GROUP BY methods.parameters;";
   var params = dbExec(sqlstr);
@@ -85,7 +86,7 @@ sc.methodSelect = function()
   clearSelectBox(paramSelectBox);
 
   var newOption = document.createElement("option");
-  param_select_box.add(newOption);
+  paramSelectBox.add(newOption);
 
   if ((dbType === "sqlite" && params[0]) || (dbType === "mysql" && params))
   {
@@ -119,28 +120,28 @@ sc.methodSelect = function()
 // Called when the user selects parameters.
 // Called when a set of parameters is selected.  Now we are ready to draw the
 // chart.
-rc.paramSelect = function()
+sc.paramSelect = function()
 {
   // The user has selected a library and parameters.  Now we need to generate
   // the list of datasets.
   var methodSelectBox = document.getElementById("method_select");
-  rc.method_name = methodSelectBox.options[methodSelectBox.selectedIndex].text;
+  sc.methodName = methodSelectBox.options[methodSelectBox.selectedIndex].text;
   var paramSelectBox = document.getElementById("param_select");
   var paramNameFull = paramSelectBox.options[paramSelectBox.selectedIndex].text;
   var sweepId = paramSelectBox.options[paramSelectBox.selectedIndex].id;
 
-  sc.param_name = param_name_full.split("(").slice(0, -1).join("(").replace(/^\s+|\s+$/g, ''); // At higher scope.
+  sc.paramName = paramNameFull.split("(").slice(0, -1).join("(").replace(/^\s+|\s+$/g, ''); // At higher scope.
 
   var sqlstr = "SELECT DISTINCT datasets.name FROM datasets, results, methods "
       + "WHERE datasets.id = results.dataset_id AND methods.name = '"
-      + sc.method_name + "' AND methods.sweep_id = " + sweepId + " AND "
-      + "results.method_id = methods.id AND methods.parameters = " + sc.paramName
-      + ";";
+      + sc.methodName + "' AND methods.sweep_id = " + sweepId + " AND "
+      + "results.method_id = methods.id AND methods.parameters = '" + sc.paramName
+      + "';";
   var datasets = dbExec(sqlstr);
-  console.log(JSON.stringify(params));
+  console.log(JSON.stringify(datasets));
 
   // Loop through the results and fill the third list box.
-  var datasetSelectBox = document.getElementById("dataset_select");
+  var datasetSelectBox = document.getElementById("main_dataset_select");
   clearSelectBox(datasetSelectBox);
 
   var newOption = document.createElement("option");
@@ -161,4 +162,318 @@ rc.paramSelect = function()
   }
 
   datasetSelectBox.selectedIndex = 0;
+}
+
+sc.datasetSelect = function()
+{
+  // The user selected a dataset, so now we can plot.
+  var methodSelectBox = document.getElementById("method_select");
+  sc.methodName = methodSelectBox.options[methodSelectBox.selectedIndex].text;
+  var paramSelectBox = document.getElementById("param_select");
+  var paramNameFull = paramSelectBox.options[paramSelectBox.selectedIndex].text;
+  sc.sweepId = paramSelectBox.options[paramSelectBox.selectedIndex].id;
+  var datasetSelectBox = document.getElementById("main_dataset_select");
+  var datasetName =
+      datasetSelectBox.options[datasetSelectBox.selectedIndex].text;
+
+  sc.paramName = paramNameFull.split("(").slice(0, -1).join("(").replace(/^\s+|\s+$/g, '');
+
+  var sqlstr = "SELECT DISTINCT * FROM "
+      + "(SELECT results.time as time, results.var as var, "
+      + "        results.sweep_elem_id as sweep_elem_id, libraries.name as lib,"
+      + "        max(results.build_id) as bid, datasets.instances as di, "
+      + "        datasets.attributes as da, datasets.size as ds"
+      + " FROM results, datasets, methods, libraries"
+      + " WHERE results.dataset_id = datasets.id"
+      + "   AND results.method_id = methods.id"
+      + "   AND methods.name = '" + sc.methodName + "'"
+      + "   AND methods.parameters = '" + sc.paramName + "'"
+      + "   AND libraries.id = results.libary_id"
+      + "   AND datasets.name = '" + datasetName + "'"
+      + " GROUP BY lib, sweep_elem_id)"
+      + "tmp GROUP BY sweep_elem_id, lib;";
+
+  sc.results = dbExec(sqlstr);
+  sc.results = dbType === "sqlite" ? sc.results[0].values : sc.results;
+
+  // Obtain unique list of libraries.
+  sc.libraries = sc.results.map(
+      function(d) {
+          return dbType === "sqlite" ? d[3] : d.lib;
+      }).reduce(
+      function(p, c) {
+          if (p.indexOf(c) < 0) p.push(c); return p;
+      }, []);
+
+  // By default, all libraries are active.
+  sc.activeLibraries = {};
+  for (i = 0; i < sc.libraries.length; ++i)
+  {
+    sc.activeLibraries[sc.libraries[i]] = true;
+  }
+
+  clearChart();
+  buildChart();
+}
+
+sc.clearChart = function()
+{
+  d3.select("svg").remove();
+}
+
+sc.buildChart = function()
+{
+  sc.results = sc.results.map(
+      function(d)
+      {
+        var runtime = dbType === "sqlite" ? d[0] : d.time;
+        if (runtime == -2)
+        {
+          if (dbType === "sqlite")
+            d[0] = "failure";
+          else
+            d.time = "failure";
+        }
+        else if (runtime == -1)
+        {
+          if (dbType === "sqlite")
+            d[0] = ">9000";
+          else
+            d.time = "failure";
+        }
+
+        return d;
+      });
+
+    // Get the parameter name we are sweeping.
+  var params = JSON.parse(sc.paramName);
+  var name = "";
+  for (var i in params)
+  {
+    if (params[i].search(/sweep\(/) !== -1)
+    {
+      name = i;
+      break;
+    }
+  }
+
+  // Get lists of active libraries.
+  var activeLibraryList = sc.libraries.map(function(d) { return d; }).reduce(
+      function(p, c)
+      {
+        if (sc.activeLibraries[c] == true) 
+          p.push(c);
+        return p;
+      }, []);
+
+  var maxRuntime = d3.max(sc.results,
+      function(d)
+      {
+        if (sc.activeLibraries[dbType === "sqlite" ? d[3] : d.lib] == false)
+          return 0;
+        else
+          return mapRuntime(dbType === "sqlite" ? d[0] : d.time, 0);
+      });
+  // Increase so we have 16 spare pixels at the top.
+  maxRuntime *= ((height + 16) / height);
+
+  var runtimeScale = d3.scale.linear()
+      .domain([0, maxRuntime])
+      .range([height, 0]);
+
+  // We need to find out how big the sweep is.
+  var sweepSql = "SELECT type, begin, step, end FROM sweeps where id = " + sc.sweepId;
+  var sweepResults = dbExec(sweepSql);
+  sweepResults = dbType === "sqlite" ? sweepResults[0].values : sweepResults.results;
+
+  var func = (dbType === "sqlite" ? sweepResults[0][0] : sweepResults[0].type) === "int" ? parseInt : parseFloat;
+  var start = func(dbType === "sqlite" ? sweepResults[0][1] : sweepResults[0].start);
+  var step = func(dbType === "sqlite" ? sweepResults[0][2] : sweepResults[0].step);
+  var end = func(dbType === "sqlite" ? sweepResults[0][3] : sweepResults[0].end);
+
+  var sweepScale = d3.scale.linear()
+      .domain([start, end])
+      .range([0, width]);
+
+  var xAxis = d3.svg.axis().scale(sweepScale).orient("bottom");
+  var yAxis = d3.svg.axis().scale(runtimeScale).orient("left").tickFormat(d3.format(".2f"));
+
+  // Create svg object.
+  var svg = d3.select(".svgholder").append("svg")
+      .attr("width", width + margin.left + margin.right)
+      .attr("height", height + margin.top + margin.bottom)
+      .append("g")
+      .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+
+  // Add x axis.
+  svg.append("g").attr("id", "xaxis")
+      .attr("class", "x axis")
+      .attr("transform", "translate(0, " + height + ")")
+      .call(xAxis)
+      .append("text")
+      .style("text-anchor", "end")
+      .attr("dx", 500)
+      .attr("dy", "3em")
+      .text("Value of parameter '" + name + "'");
+
+  // Add y axis.
+  svg.append("g").attr("id", "yaxis")
+      .attr("class", "y axis")
+      .call(yAxis)
+      .append("text")
+      .attr("transform", "rotate(-90)")
+      .attr("y", 6)
+      .attr("dy", ".71em")
+      .style("text-anchor", "end")
+      .text("Runtime (s)");
+
+  // Create tooltips.
+  var tip = d3.tip()
+      .attr("class", "d3-tip")
+      .offset([-10, 0])
+      .html(function(d) {
+          var runtime = d[0];
+          if (d[0] != ">9000" && d[0] != "failure") {
+            runtime = d[0].toFixed(2);
+          }
+          return "<strong>" + d[3] + "; " + name + ": " + (start + step * d[2]) + ":</strong> <span style='color:yellow'>" + runtime + "s</span>"; });
+  svg.call(tip);
+
+  // Add all of the data points.
+  var lineFunc = d3.svg.line()
+      .x(function(d) { return sweepScale(dbType === "sqlite" ? start + step * d[2] : start + step * d.sweep_elem_id); })
+      .y(function(d) { return runtimeScale(mapRuntime(
+          dbType === "sqlite" ? d[0] : d.time, maxRuntime)); })
+      .interpolate("linear");
+
+  var lineResults = []
+  for (var l in sc.libraries)
+  {
+    if (sc.activeLibraries[sc.libraries[l]] == true)
+    {
+      lineResults.push(sc.results.map(function(d) { return d; }).reduce(function(p, c) { if(c[3] == sc.libraries[l]) { p.push(c); } return p; }, []));
+    }
+    else
+    {
+      lineResults.push([]);
+    }
+  }
+
+  for (i = 0; i < lineResults.length; ++i)
+  {
+    console.log(JSON.stringify(lineResults[i]));
+    if (lineFunc(lineResults[i]) != null)
+    {
+      svg.append('svg:path')
+          .attr('d', lineFunc(lineResults[i]))
+          .attr('stroke', color(sc.libraries[i]))
+          .attr('stroke-width', 2)
+          .attr('fill', 'none');
+    }
+  }
+
+  for (i = 0; i < lineResults.length; i++)
+  {
+    if (lineFunc(lineResults[i]) == null)
+      continue;
+
+    // Colored circle enclosed in white circle enclosed in background color
+    // circle; looks kind of nice.
+    svg.selectAll("dot").data(lineResults[i]).enter().append("circle")
+        .attr("r", 6)
+        .attr("cx", function(d) { return sweepScale(dbType === "sqlite" ? start + step * d[2] : start + step * d.sweep_elem_id); })
+        .attr("cy", function(d) { return runtimeScale(mapRuntime(dbType === "sqlite" ? d[0] : d.time, maxRuntime)); })
+        .attr('fill', '#222222')
+        .on('mouseover', tip.show)
+        .on('mouseout', tip.hide);
+    svg.selectAll("dot").data(lineResults[i]).enter().append("circle")
+        .attr("r", 4)
+        .attr("cx", function(d) { return sweepScale(dbType === "sqlite" ? start + step * d[2] : start + step * d.sweep_elem_id); })
+        .attr("cy", function(d) { return runtimeScale(mapRuntime(dbType === "sqlite" ? d[0] : d.time, maxRuntime)); })
+        .attr('fill', '#ffffff')
+        .on('mouseover', tip.show)
+        .on('mouseout', tip.hide);
+    svg.selectAll("dot").data(lineResults[i]).enter().append("circle")
+        .attr("r", 3)
+        .attr("cx", function(d) { return sweepScale(dbType === "sqlite" ? start + step * d[2] : start + step * d.sweep_elem_id); })
+        .attr("cy", function(d) { return runtimeScale(mapRuntime(dbType === "sqlite" ? d[0] : d.time, maxRuntime)); })
+        .attr('fill', function(d) { return color(d[4]) })
+        .on('mouseover', tip.show)
+        .on('mouseout', tip.hide);
+  }
+
+  // Create the library selector.
+  var librarySelectTitle = d3.select(".legendholder").append("div")
+    .attr("class", "library-select-title");
+  librarySelectTitle.append("div")
+    .attr("class", "library-select-title-text")
+    .text("Libraries:");
+  librarySelectTitle.append("div")
+    .attr("class", "library-select-title-open-paren")
+    .text("(");
+  librarySelectTitle.append("div")
+    .attr("class", "library-select-title-enable-all")
+    .text("enable all")
+    .on('click', function() { sc.enableAllLibraries(); });
+  librarySelectTitle.append("div")
+    .attr("class", "library-select-title-bar")
+    .text("|");
+  librarySelectTitle.append("div")
+    .attr("class", "library-select-title-disable-all")
+    .text("disable all")
+    .on('click', function() { sc.disableAllLibraries(); });
+  librarySelectTitle.append("div")
+    .attr("class", "library-select-title-close-paren")
+    .text(")");
+
+  var libraryDivs = d3.select(".legendholder").selectAll("input")
+    .data(sc.libraries)
+    .enter()
+    .append("div")
+    .attr("class", "library-select-div")
+    .attr("id", function(d) { return d + '-library-checkbox-div'; });
+
+  libraryDivs.append("label")
+    .attr('for', function(d) { return d + '-library-checkbox'; })
+    .style('background', color)
+    .attr('class', 'library-select-color');
+
+  libraryDivs.append("input")
+    .property("checked", function(d) { return sc.activeLibraries[d]; })
+    .attr("type", "checkbox")
+    .attr("id", function(d) { return d + '-library-checkbox'; })
+    .attr('class', 'library-select-box')
+    .attr("onClick", function(d, i) { return "sc.toggleLibrary(\"" + d + "\");"; });
+
+  libraryDivs.append("label")
+    .attr('for', function(d) { return d + '-library-checkbox'; })
+    .attr('class', 'library-select-label')
+    .text(function(d) { return d; });
+}
+
+// Toggle a library to on or off.
+sc.toggleLibrary = function(library)
+{
+  sc.activeLibraries[library] = !sc.activeLibraries[library];
+
+  clearChart();
+  buildChart();
+}
+
+// Set all libraries on.
+sc.enableAllLibraries = function()
+{
+  for (v in sc.activeLibraries) { sc.activeLibraries[v] = true; }
+
+  clearChart();
+  buildChart();
+}
+
+// Set all libraries off.
+sc.disableAllLibraries = function()
+{
+  for (v in sc.activeLibraries) { sc.activeLibraries[v] = false; }
+
+  clearChart();
+  buildChart();
 }

--- a/reports/js/benchmarks/sweep-comparison-view.js
+++ b/reports/js/benchmarks/sweep-comparison-view.js
@@ -40,6 +40,11 @@ sc.onTypeSelect = function()
   sc.listMethods();
 }
 
+sc.clear = function()
+{
+  sc.clearChart();
+}
+
 // List the available methods where there is a sweep.
 sc.listMethods = function()
 {

--- a/reports/js/benchmarks/sweep-comparison-view.js
+++ b/reports/js/benchmarks/sweep-comparison-view.js
@@ -1,0 +1,164 @@
+// Define namespace: sc = sweep comparison.
+var sc = sc = sc || {};
+
+sc.method_name = "";
+sc.param_name = "";
+sc.dataset = "";
+sc.libraries = [];
+sc.active_libraries = [];
+sc.results = [];
+
+// This chart type has been selected.
+sc.onTypeSelect = function()
+{
+  // The user needs to be able to select a method, then parameters, then a
+  // dataset.
+  var selectHolder = d3.select(".selectholder");
+  selectHolder.append("label")
+      .attr("for", "method_select")
+      .attr("class", "method-select-label")
+      .text("Select method:");
+  selectHolder.append("select")
+      .attr("id", "method_select")
+      .attr("onchange", "sc.methodSelect()");
+  selectHolder.append("label")
+      .attr("for", "param_select")
+      .attr("class", "param-select-label")
+      .text("Select parameters:");
+  selectHolder.append("select")
+      .attr("id", "param_select")
+      .attr("onchange", "sc.paramSelect()");
+  selectHolder.append("label")
+        .attr("for", "main_dataset_select")
+        .attr("class", "main-dataset-select-label")
+        .text("Select dataset:");
+  selectHolder.append("select")
+        .attr("id", "main_dataset_select")
+        .attr("onchange", "sc.datasetSelect()");
+
+  sc.listMethods();
+}
+
+// List the available methods where there is a sweep.
+sc.listMethods = function()
+{
+  var methods = dbExec("SELECT DISTINCT methods.name FROM methods, results "
+      + "WHERE methods.id = results.method_id AND methods.sweep_id != -1 "
+      + "ORDER BY name;");
+  var methodSelectBox = document.getElementById("method_select");
+
+  // Remove old things.
+  clearSelectBox(methodSelectBox);
+
+  // Add new things.
+  var length = dbType === "sqlite" ? methods[0].values.length : methods.length;
+  for (i = 0; i < length; i++)
+  {
+    var newOption = document.createElement("option");
+    newOption.text = dbType === "sqlite" ? methods[0].values[i] :
+        methods[i].name;
+    methodSelectBox.add(newOption);
+  }
+  methodSelectBox.selectedIndex = -1;
+
+  // Clear parameters box.
+  clearSelectBox(document.getElementById("param_select"));
+}
+
+// Called when the user selects a method.
+sc.methodSelect = function()
+{
+  // Extract the name of the method we selected.
+  var methodSelectBox = document.getElementById("method_select");
+  sc.methodName = methodSelectBox.options[methodSelectBox.selectedIndex].text; // At higher scope.
+
+  var sqlstr = "SELECT DISTINCT methods.parameters, methods.sweep_id, " +
+      "metrics.libary_id, COUNT(DISTINCT metrics.libary_id) AS count FROM " +
+      "methods, metrics WHERE methods.name = '" + sc.method_name +
+      "' AND methods.id = metrics.method_id AND methods.sweep_id != -1 " +
+      "GROUP BY methods.parameters;";
+  var params = dbExec(sqlstr);
+  console.log(JSON.stringify(params));
+
+  // Loop through results and fill the second list box.
+  var paramSelectBox = document.getElementById("param_select");
+  clearSelectBox(paramSelectBox);
+
+  var newOption = document.createElement("option");
+  param_select_box.add(newOption);
+
+  if ((dbType === "sqlite" && params[0]) || (dbType === "mysql" && params))
+  {
+    // Put in the new options.
+    var length = dbType === "sqlite" ? params[0].values.length : params.length;
+    for (i = 0; i < length; i++)
+    {
+      var newOption = document.createElement("option");
+
+      var parameters = dbType === "sqlite" ? params[0].values[i][0] : params[i].parameters;
+      var sweepId = dbType === "sqlite" ? params[0].values[i][1] : params[i].sweep_id;
+      var libraries = dbType === "sqlite" ? params[0].values[i][3] : params[i].count;
+
+      if (parameters)
+      {
+        newOption.text = parameters + " (" + libraries + " libraries)";
+      }
+      else
+      {
+        newOption.text = "[no parameters] (" + libraries + " libraries)";
+      }
+      newOption.id = sweepId;
+
+      paramSelectBox.add(newOption);
+    }
+  }
+
+  paramSelectBox.selectedIndex = 0;
+}
+
+// Called when the user selects parameters.
+// Called when a set of parameters is selected.  Now we are ready to draw the
+// chart.
+rc.paramSelect = function()
+{
+  // The user has selected a library and parameters.  Now we need to generate
+  // the list of datasets.
+  var methodSelectBox = document.getElementById("method_select");
+  rc.method_name = methodSelectBox.options[methodSelectBox.selectedIndex].text;
+  var paramSelectBox = document.getElementById("param_select");
+  var paramNameFull = paramSelectBox.options[paramSelectBox.selectedIndex].text;
+  var sweepId = paramSelectBox.options[paramSelectBox.selectedIndex].id;
+
+  sc.param_name = param_name_full.split("(").slice(0, -1).join("(").replace(/^\s+|\s+$/g, ''); // At higher scope.
+
+  var sqlstr = "SELECT DISTINCT datasets.name FROM datasets, results, methods "
+      + "WHERE datasets.id = results.dataset_id AND methods.name = '"
+      + sc.method_name + "' AND methods.sweep_id = " + sweepId + " AND "
+      + "results.method_id = methods.id AND methods.parameters = " + sc.paramName
+      + ";";
+  var datasets = dbExec(sqlstr);
+  console.log(JSON.stringify(params));
+
+  // Loop through the results and fill the third list box.
+  var datasetSelectBox = document.getElementById("dataset_select");
+  clearSelectBox(datasetSelectBox);
+
+  var newOption = document.createElement("option");
+  datasetSelectBox.add(newOption);
+
+  if ((dbType === "sqlite" && datasets[0]) || (dbType === "mysql" && datasets))
+  {
+    // Put in the datasets.
+    var length = dbType === "sqlite" ? datasets[0].values.length : datasets.length;
+    for (i = 0; i < length; i++)
+    {
+      newOption = document.createElement("option");
+
+      var datasetName = dbType === "sqlite" ? datasets[0].values[i][0] : datasets[i].name;
+      newOption.text = datasetName;
+      datasetSelectBox.add(newOption);
+    }
+  }
+
+  datasetSelectBox.selectedIndex = 0;
+}

--- a/reports/js/benchmarks/sweep-metric-comparison-view.js
+++ b/reports/js/benchmarks/sweep-metric-comparison-view.js
@@ -1,0 +1,492 @@
+// Define namespace: smc = sweep metric comparison.
+var smc = smc = smc || {};
+
+smc.methodName = "";
+smc.paramName = "";
+smc.dataset = "";
+smc.libraries = [];
+smc.activeLibraries = [];
+smc.results = [];
+smc.sweepId = -1;
+
+// This chart type has been selected.
+smc.onTypeSelect = function()
+{
+  // The user needs to be able to select a method, then parameters, then a
+  // dataset.
+  var selectHolder = d3.select(".selectholder");
+  selectHolder.append("label")
+      .attr("for", "method_select")
+      .attr("class", "method-select-label")
+      .text("Select method:");
+  selectHolder.append("select")
+      .attr("id", "method_select")
+      .attr("onchange", "smc.methodSelect()");
+  selectHolder.append("label")
+      .attr("for", "param_select")
+      .attr("class", "param-select-label")
+      .text("Select parameters:");
+  selectHolder.append("select")
+      .attr("id", "param_select")
+      .attr("onchange", "smc.paramSelect()");
+  selectHolder.append("label")
+      .attr("for", "main_dataset_select")
+      .attr("class", "main-dataset-select-label")
+      .text("Select dataset:");
+  selectHolder.append("select")
+      .attr("id", "main_dataset_select")
+      .attr("onchange", "smc.datasetSelect()");
+  selectHolder.append("label")
+      .attr("for", "metric_select")
+      .attr("class", "metric-select-label")
+      .text("Select metric:");
+  selectHolder.append("select")
+      .attr("id", "metric_select")
+      .attr("onchange", "smc.metricSelect()");
+
+  smc.listMethods();
+}
+
+// List the available methods where there is a sweep.
+smc.listMethods = function()
+{
+  var methods = dbExec("SELECT DISTINCT methods.name FROM methods, results "
+      + "WHERE methods.id = results.method_id AND methods.sweep_id != -1 "
+      + "ORDER BY name;");
+  var methodSelectBox = document.getElementById("method_select");
+
+  // Remove old things.
+  clearSelectBox(methodSelectBox);
+
+  // Add new things.
+  var length = dbType === "sqlite" ? methods[0].values.length : methods.length;
+  for (i = 0; i < length; i++)
+  {
+    var newOption = document.createElement("option");
+    newOption.text = dbType === "sqlite" ? methods[0].values[i] :
+        methods[i].name;
+    methodSelectBox.add(newOption);
+  }
+  methodSelectBox.selectedIndex = -1;
+
+  // Clear parameters box.
+  clearSelectBox(document.getElementById("param_select"));
+}
+
+// Called when the user selects a method.
+smc.methodSelect = function()
+{
+  // Extract the name of the method we selected.
+  var methodSelectBox = document.getElementById("method_select");
+  smc.methodName = methodSelectBox.options[methodSelectBox.selectedIndex].text; // At higher scope.
+
+  var sqlstr = "SELECT DISTINCT methods.parameters, methods.sweep_id, " +
+      "metrics.libary_id, COUNT(DISTINCT metrics.libary_id) AS count FROM " +
+      "methods, metrics WHERE methods.name = '" + smc.methodName +
+      "' AND methods.id = metrics.method_id AND methods.sweep_id != -1 " +
+      "GROUP BY methods.parameters;";
+  var params = dbExec(sqlstr);
+  console.log(JSON.stringify(params));
+
+  // Loop through results and fill the second list box.
+  var paramSelectBox = document.getElementById("param_select");
+  clearSelectBox(paramSelectBox);
+
+  var newOption = document.createElement("option");
+  paramSelectBox.add(newOption);
+
+  if ((dbType === "sqlite" && params[0]) || (dbType === "mysql" && params))
+  {
+    // Put in the new options.
+    var length = dbType === "sqlite" ? params[0].values.length : params.length;
+    for (i = 0; i < length; i++)
+    {
+      var newOption = document.createElement("option");
+
+      var parameters = dbType === "sqlite" ? params[0].values[i][0] : params[i].parameters;
+      var sweepId = dbType === "sqlite" ? params[0].values[i][1] : params[i].sweep_id;
+      var libraries = dbType === "sqlite" ? params[0].values[i][3] : params[i].count;
+
+      if (parameters)
+      {
+        newOption.text = parameters + " (" + libraries + " libraries)";
+      }
+      else
+      {
+        newOption.text = "[no parameters] (" + libraries + " libraries)";
+      }
+      newOption.id = sweepId;
+
+      paramSelectBox.add(newOption);
+    }
+  }
+
+  paramSelectBox.selectedIndex = 0;
+}
+
+// Called when the user selects parameters.
+// Called when a set of parameters is selected.  Now we are ready to draw the
+// chart.
+smc.paramSelect = function()
+{
+  // The user has selected a library and parameters.  Now we need to generate
+  // the list of datasets.
+  var methodSelectBox = document.getElementById("method_select");
+  smc.methodName = methodSelectBox.options[methodSelectBox.selectedIndex].text;
+  var paramSelectBox = document.getElementById("param_select");
+  var paramNameFull = paramSelectBox.options[paramSelectBox.selectedIndex].text;
+  var sweepId = paramSelectBox.options[paramSelectBox.selectedIndex].id;
+
+  smc.paramName = paramNameFull.split("(").slice(0, -1).join("(").replace(/^\s+|\s+$/g, ''); // At higher scope.
+
+  var sqlstr = "SELECT DISTINCT datasets.name FROM datasets, results, methods "
+      + "WHERE datasets.id = results.dataset_id AND methods.name = '"
+      + smc.methodName + "' AND methods.sweep_id = " + sweepId + " AND "
+      + "results.method_id = methods.id AND methods.parameters = '" + smc.paramName
+      + "';";
+  var datasets = dbExec(sqlstr);
+  console.log(JSON.stringify(datasets));
+
+  // Loop through the results and fill the third list box.
+  var datasetSelectBox = document.getElementById("main_dataset_select");
+  clearSelectBox(datasetSelectBox);
+
+  var newOption = document.createElement("option");
+  datasetSelectBox.add(newOption);
+
+  if ((dbType === "sqlite" && datasets[0]) || (dbType === "mysql" && datasets))
+  {
+    // Put in the datasets.
+    var length = dbType === "sqlite" ? datasets[0].values.length : datasets.length;
+    for (i = 0; i < length; i++)
+    {
+      newOption = document.createElement("option");
+
+      var datasetName = dbType === "sqlite" ? datasets[0].values[i][0] : datasets[i].name;
+      newOption.text = datasetName;
+      datasetSelectBox.add(newOption);
+    }
+  }
+
+  datasetSelectBox.selectedIndex = 0;
+}
+
+smc.datasetSelect = function()
+{
+  // The user selected a dataset, so now we can plot.
+  var methodSelectBox = document.getElementById("method_select");
+  smc.methodName = methodSelectBox.options[methodSelectBox.selectedIndex].text;
+  var paramSelectBox = document.getElementById("param_select");
+  var paramNameFull = paramSelectBox.options[paramSelectBox.selectedIndex].text;
+  smc.sweepId = paramSelectBox.options[paramSelectBox.selectedIndex].id;
+  var datasetSelectBox = document.getElementById("main_dataset_select");
+  var datasetName =
+      datasetSelectBox.options[datasetSelectBox.selectedIndex].text;
+
+  smc.paramName = paramNameFull.split("(").slice(0, -1).join("(").replace(/^\s+|\s+$/g, '');
+
+  // What metrics do we have available?
+  // TODO: from here
+}
+
+smc.metricSelect = function()
+
+  var sqlstr = "SELECT DISTINCT * FROM "
+      + "(SELECT results.time as time, results.var as var, "
+      + "        results.sweep_elem_id as sweep_elem_id, libraries.name as lib,"
+      + "        max(results.build_id) as bid, datasets.instances as di, "
+      + "        datasets.attributes as da, datasets.size as ds"
+      + " FROM results, datasets, methods, libraries"
+      + " WHERE results.dataset_id = datasets.id"
+      + "   AND results.method_id = methods.id"
+      + "   AND methods.name = '" + smc.methodName + "'"
+      + "   AND methods.parameters = '" + smc.paramName + "'"
+      + "   AND libraries.id = results.libary_id"
+      + "   AND datasets.name = '" + datasetName + "'"
+      + " GROUP BY lib, sweep_elem_id)"
+      + "tmp GROUP BY sweep_elem_id, lib;";
+
+  smc.results = dbExec(sqlstr);
+  smc.results = dbType === "sqlite" ? sc.results[0].values : sc.results;
+
+  // Obtain unique list of libraries.
+  smc.libraries = sc.results.map(
+      function(d) {
+          return dbType === "sqlite" ? d[3] : d.lib;
+      }).reduce(
+      function(p, c) {
+          if (p.indexOf(c) < 0) p.push(c); return p;
+      }, []);
+
+  // By default, all libraries are active.
+  smc.activeLibraries = {};
+  for (i = 0; i < smc.libraries.length; ++i)
+  {
+    smc.activeLibraries[sc.libraries[i]] = true;
+  }
+
+  clearChart();
+  buildChart();
+}
+
+smc.clearChart = function()
+{
+  d3.select("svg").remove();
+}
+
+smc.buildChart = function()
+{
+  smc.results = sc.results.map(
+      function(d)
+      {
+        var runtime = dbType === "sqlite" ? d[0] : d.time;
+        if (runtime == -2)
+        {
+          if (dbType === "sqlite")
+            d[0] = "failure";
+          else
+            d.time = "failure";
+        }
+        else if (runtime == -1)
+        {
+          if (dbType === "sqlite")
+            d[0] = ">9000";
+          else
+            d.time = "failure";
+        }
+
+        return d;
+      });
+
+    // Get the parameter name we are sweeping.
+  var params = JSON.parse(smc.paramName);
+  var name = "";
+  for (var i in params)
+  {
+    if (params[i].search(/sweep\(/) !== -1)
+    {
+      name = i;
+      break;
+    }
+  }
+
+  // Get lists of active libraries.
+  var activeLibraryList = smc.libraries.map(function(d) { return d; }).reduce(
+      function(p, c)
+      {
+        if (smc.activeLibraries[c] == true) 
+          p.push(c);
+        return p;
+      }, []);
+
+  var maxRuntime = d3.max(smc.results,
+      function(d)
+      {
+        if (smc.activeLibraries[dbType === "sqlite" ? d[3] : d.lib] == false)
+          return 0;
+        else
+          return mapRuntime(dbType === "sqlite" ? d[0] : d.time, 0);
+      });
+  // Increase so we have 16 spare pixels at the top.
+  maxRuntime *= ((height + 16) / height);
+
+  var runtimeScale = d3.scale.linear()
+      .domain([0, maxRuntime])
+      .range([height, 0]);
+
+  // We need to find out how big the sweep is.
+  var sweepSql = "SELECT type, begin, step, end FROM sweeps where id = " + smc.sweepId;
+  var sweepResults = dbExec(sweepSql);
+  sweepResults = dbType === "sqlite" ? sweepResults[0].values : sweepResults.results;
+
+  var func = (dbType === "sqlite" ? sweepResults[0][0] : sweepResults[0].type) === "int" ? parseInt : parseFloat;
+  var start = func(dbType === "sqlite" ? sweepResults[0][1] : sweepResults[0].start);
+  var step = func(dbType === "sqlite" ? sweepResults[0][2] : sweepResults[0].step);
+  var end = func(dbType === "sqlite" ? sweepResults[0][3] : sweepResults[0].end);
+
+  var sweepScale = d3.scale.linear()
+      .domain([start, end])
+      .range([0, width]);
+
+  var xAxis = d3.svg.axis().scale(sweepScale).orient("bottom");
+  var yAxis = d3.svg.axis().scale(runtimeScale).orient("left").tickFormat(d3.format(".2f"));
+
+  // Create svg object.
+  var svg = d3.select(".svgholder").append("svg")
+      .attr("width", width + margin.left + margin.right)
+      .attr("height", height + margin.top + margin.bottom)
+      .append("g")
+      .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+
+  // Add x axis.
+  svg.append("g").attr("id", "xaxis")
+      .attr("class", "x axis")
+      .attr("transform", "translate(0, " + height + ")")
+      .call(xAxis)
+      .append("text")
+      .style("text-anchor", "end")
+      .attr("dx", 500)
+      .attr("dy", "3em")
+      .text("Value of parameter '" + name + "'");
+
+  // Add y axis.
+  svg.append("g").attr("id", "yaxis")
+      .attr("class", "y axis")
+      .call(yAxis)
+      .append("text")
+      .attr("transform", "rotate(-90)")
+      .attr("y", 6)
+      .attr("dy", ".71em")
+      .style("text-anchor", "end")
+      .text("Runtime (s)");
+
+  // Create tooltips.
+  var tip = d3.tip()
+      .attr("class", "d3-tip")
+      .offset([-10, 0])
+      .html(function(d) {
+          var runtime = d[0];
+          if (d[0] != ">9000" && d[0] != "failure") {
+            runtime = d[0].toFixed(2);
+          }
+          return "<strong>" + d[3] + "; " + name + ": " + (start + step * d[2]) + ":</strong> <span style='color:yellow'>" + runtime + "s</span>"; });
+  svg.call(tip);
+
+  // Add all of the data points.
+  var lineFunc = d3.svg.line()
+      .x(function(d) { return sweepScale(dbType === "sqlite" ? start + step * d[2] : start + step * d.sweep_elem_id); })
+      .y(function(d) { return runtimeScale(mapRuntime(
+          dbType === "sqlite" ? d[0] : d.time, maxRuntime)); })
+      .interpolate("linear");
+
+  var lineResults = []
+  for (var l in smc.libraries)
+  {
+    if (smc.activeLibraries[sc.libraries[l]] == true)
+    {
+      lineResults.push(smc.results.map(function(d) { return d; }).reduce(function(p, c) { if(c[3] == sc.libraries[l]) { p.push(c); } return p; }, []));
+    }
+    else
+    {
+      lineResults.push([]);
+    }
+  }
+
+  for (i = 0; i < lineResults.length; ++i)
+  {
+    console.log(JSON.stringify(lineResults[i]));
+    if (lineFunc(lineResults[i]) != null)
+    {
+      svg.append('svg:path')
+          .attr('d', lineFunc(lineResults[i]))
+          .attr('stroke', color(smc.libraries[i]))
+          .attr('stroke-width', 2)
+          .attr('fill', 'none');
+    }
+  }
+
+  for (i = 0; i < lineResults.length; i++)
+  {
+    if (lineFunc(lineResults[i]) == null)
+      continue;
+
+    // Colored circle enclosed in white circle enclosed in background color
+    // circle; looks kind of nice.
+    svg.selectAll("dot").data(lineResults[i]).enter().append("circle")
+        .attr("r", 6)
+        .attr("cx", function(d) { return sweepScale(dbType === "sqlite" ? start + step * d[2] : start + step * d.sweep_elem_id); })
+        .attr("cy", function(d) { return runtimeScale(mapRuntime(dbType === "sqlite" ? d[0] : d.time, maxRuntime)); })
+        .attr('fill', '#222222')
+        .on('mouseover', tip.show)
+        .on('mouseout', tip.hide);
+    svg.selectAll("dot").data(lineResults[i]).enter().append("circle")
+        .attr("r", 4)
+        .attr("cx", function(d) { return sweepScale(dbType === "sqlite" ? start + step * d[2] : start + step * d.sweep_elem_id); })
+        .attr("cy", function(d) { return runtimeScale(mapRuntime(dbType === "sqlite" ? d[0] : d.time, maxRuntime)); })
+        .attr('fill', '#ffffff')
+        .on('mouseover', tip.show)
+        .on('mouseout', tip.hide);
+    svg.selectAll("dot").data(lineResults[i]).enter().append("circle")
+        .attr("r", 3)
+        .attr("cx", function(d) { return sweepScale(dbType === "sqlite" ? start + step * d[2] : start + step * d.sweep_elem_id); })
+        .attr("cy", function(d) { return runtimeScale(mapRuntime(dbType === "sqlite" ? d[0] : d.time, maxRuntime)); })
+        .attr('fill', function(d) { return color(d[4]) })
+        .on('mouseover', tip.show)
+        .on('mouseout', tip.hide);
+  }
+
+  // Create the library selector.
+  var librarySelectTitle = d3.select(".legendholder").append("div")
+    .attr("class", "library-select-title");
+  librarySelectTitle.append("div")
+    .attr("class", "library-select-title-text")
+    .text("Libraries:");
+  librarySelectTitle.append("div")
+    .attr("class", "library-select-title-open-paren")
+    .text("(");
+  librarySelectTitle.append("div")
+    .attr("class", "library-select-title-enable-all")
+    .text("enable all")
+    .on('click', function() { smc.enableAllLibraries(); });
+  librarySelectTitle.append("div")
+    .attr("class", "library-select-title-bar")
+    .text("|");
+  librarySelectTitle.append("div")
+    .attr("class", "library-select-title-disable-all")
+    .text("disable all")
+    .on('click', function() { smc.disableAllLibraries(); });
+  librarySelectTitle.append("div")
+    .attr("class", "library-select-title-close-paren")
+    .text(")");
+
+  var libraryDivs = d3.select(".legendholder").selectAll("input")
+    .data(smc.libraries)
+    .enter()
+    .append("div")
+    .attr("class", "library-select-div")
+    .attr("id", function(d) { return d + '-library-checkbox-div'; });
+
+  libraryDivs.append("label")
+    .attr('for', function(d) { return d + '-library-checkbox'; })
+    .style('background', color)
+    .attr('class', 'library-select-color');
+
+  libraryDivs.append("input")
+    .property("checked", function(d) { return smc.activeLibraries[d]; })
+    .attr("type", "checkbox")
+    .attr("id", function(d) { return d + '-library-checkbox'; })
+    .attr('class', 'library-select-box')
+    .attr("onClick", function(d, i) { return "smc.toggleLibrary(\"" + d + "\");"; });
+
+  libraryDivs.append("label")
+    .attr('for', function(d) { return d + '-library-checkbox'; })
+    .attr('class', 'library-select-label')
+    .text(function(d) { return d; });
+}
+
+// Toggle a library to on or off.
+smc.toggleLibrary = function(library)
+{
+  smc.activeLibraries[library] = !hc.activeLibraries[library];
+
+  clearChart();
+  buildChart();
+}
+
+// Set all libraries on.
+smc.enableAllLibraries = function()
+{
+  for (v in smc.activeLibraries) { hc.activeLibraries[v] = true; }
+
+  clearChart();
+  buildChart();
+}
+
+// Set all libraries off.
+smc.disableAllLibraries = function()
+{
+  for (v in hc.activeLibraries) { hc.activeLibraries[v] = false; }
+
+  clearChart();
+  buildChart();
+}

--- a/reports/js/benchmarks/sweep-metric-comparison-view.js
+++ b/reports/js/benchmarks/sweep-metric-comparison-view.js
@@ -47,6 +47,11 @@ smc.onTypeSelect = function()
   smc.listMethods();
 }
 
+smc.clear = function()
+{
+  smc.clearChart();
+}
+
 // List the available methods where there is a sweep.
 smc.listMethods = function()
 {

--- a/reports/js/benchmarks/sweep-metric-comparison-view.js
+++ b/reports/js/benchmarks/sweep-metric-comparison-view.js
@@ -12,6 +12,7 @@ smc.sweepId = -1;
 // This chart type has been selected.
 smc.onTypeSelect = function()
 {
+  console.log("onTypeSelect");
   // The user needs to be able to select a method, then parameters, then a
   // dataset.
   var selectHolder = d3.select(".selectholder");
@@ -186,11 +187,12 @@ smc.datasetSelect = function()
   smc.paramName = paramNameFull.split("(").slice(0, -1).join("(").replace(/^\s+|\s+$/g, '');
 
   // What metrics do we have available?
-  // TODO: from here
+  // TODO: write sql query to do this.
+  var sqlstr = " ";
 }
 
 smc.metricSelect = function()
-
+{
   var sqlstr = "SELECT DISTINCT * FROM "
       + "(SELECT results.time as time, results.var as var, "
       + "        results.sweep_elem_id as sweep_elem_id, libraries.name as lib,"


### PR DESCRIPTION
This is not the prettiest JS ever written, but it adds two views to plot both runtimes over a sweep, and metrics vs. runtime over a sweep.  Here is an image of each view:

![benchmark_1](https://user-images.githubusercontent.com/1845039/29465860-bdcbdefe-8408-11e7-9a78-17fc5ca2a6b8.png)
![benchmark_2](https://user-images.githubusercontent.com/1845039/29465864-c125f954-8408-11e7-8e21-19bcf093b0b2.png)