### PR TITLE
Reduce output messages when running benchmarks

### DIFF
--- a/util/parser.py
+++ b/util/parser.py
@@ -458,7 +458,7 @@ class Parser(object):
                 # Store the initial second dictionary with the method name as
                 # key (e.g. KPCA) in the main key/value store.
                 streamData[methodMapping.methodName] = d
-                print(streamData)
+
 
           methodMapping = self.GetConfigMethod(libraryMapping.methods)
       libraryMapping = self.GetConfigLibraryMethods()


### PR DESCRIPTION
This PR reduces the number of the message which are printed to the terminal when running `make run`. I do not know if that `print` statement was just for debugging purposes and then it was forgotten, or if it was placed there for a more sensible reason, therefore I just guarded it.

Before patch output:
```
/home/uriel/Applications/miniconda3/bin/python3 benchmark/run_benchmark.py -c config.yaml -b shogun -l False -u False -m ALLKNN --f "" --n False -r "" -p ""
[WARN ] No module named simplejson
[INFO ] CPU Model:  Intel(R) Core(TM) i3-3217U CPU @ 1.80GHz
[INFO ] Distribution: debian stretch/sid
[INFO ] Platform: x86_64
[INFO ] Memory: 7.6943359375 GB
[INFO ] CPU Cores: 4
{'general': dict_items([('timeout', 9000), ('databaseHost', 'localhost'), ('port', 3306), ('database', 'benchmarks'), ('driver', 'mysql'), ('keepReports', 20), ('bootstrap', 10), ('libraries', ['mlpack', 'shogun', 'weka', 'scikit', 'mlpy', 'flann', 'ann', 'annoy', 'mrpt', 'dlibml']), ('version', ['HEAD', '3.2.0', '3.6.11', '0.15.1', '3.5.0', '1.8.4', '1.1.2', '1.8.3', '0.1', '19.4'])]), 'DTC': {'{}': [('mlpack', [['datasets/iris_train.csv', 'datasets/iris_test.csv', 'datasets/iris_labels.csv'], ['datasets/oilspill_train.csv', 'datasets/oilspill_test.csv', 'datasets/oilspill_labels.csv'], ['datasets/scene_train.csv', 'datasets/scene_test.csv', 'datasets/scene_labels.csv'], ['datasets/webpage_train.csv', 'datasets/webpage_test.csv', 'datasets/webpage_labels.csv'], ['datasets/isolet_train.csv', 'datasets/isolet_test.csv', 'datasets/isolet_labels.csv'], ['datasets/mammography_train.csv', 'datasets/mammography_test.csv', 'datasets/mammography_labels.csv'], ['datasets/reuters_train.csv', 'datasets/reuters_test.csv', 'datasets/reuters_labels.csv'], ['datasets/abalone19_train.csv', 'datasets/abalone19_test.csv', 'datasets/abalone19_labels.csv'], ['datasets/sickEuthyroid_train.csv', 'datasets/sickEuthyroid_test.csv', 'datasets/sickEuthyroid_labels.csv'], ['datasets/abalone7_train.csv', 'datasets/abalone7_test.csv', 'datasets/abalone7_labels.csv'], ['datasets/satellite_train.csv', 'datasets/satellite_test.csv', 'datasets/satellite_labels.csv'], ['datasets/ecoli_train.csv', 'datasets/ecoli_test.csv', 'datasets/ecoli_labels.csv']], 3, 'methods/mlpack/decision_tree.py', ['csv', 'txt', 'arff'], ['metric'], 'None', ['None'])]}}
{'general': dict_items([('timeout', 9000), ('databaseHost', 'localhost'), ('port', 3306), ('database', 'benchmarks'), ('driver', 'mysql'), ('keepReports', 20), ('bootstrap', 10), ('libraries', ['mlpack', 'shogun', 'weka', 'scikit', 'mlpy', 'flann', 'ann', 'annoy', 'mrpt', 'dlibml']), ('version', ['HEAD', '3.2.0', '3.6.11', '0.15.1', '3.5.0', '1.8.4', '1.1.2', '1.8.3', '0.1', '19.4'])]), 'DTC': {'{}': [('mlpack', [['datasets/iris_train.csv', 'datasets/iris_test.csv', 'datasets/iris_labels.csv'], ['datasets/oilspill_train.csv', 'datasets/oilspill_test.csv', 'datasets/oilspill_labels.csv'], ['datasets/scene_train.csv', 'datasets/scene_test.csv', 'datasets/scene_labels.csv'], ['datasets/webpage_train.csv', 'datasets/webpage_test.csv', 'datasets/webpage_labels.csv'], ['datasets/isolet_train.csv', 'datasets/isolet_test.csv', 'datasets/isolet_labels.csv'], ['datasets/mammography_train.csv', 'datasets/mammography_test.csv', 'datasets/mammography_labels.csv'], ['datasets/reuters_train.csv', 'datasets/reuters_test.csv', 'datasets/reuters_labels.csv'], ['datasets/abalone19_train.csv', 'datasets/abalone19_test.csv', 'datasets/abalone19_labels.csv'], ['datasets/sickEuthyroid_train.csv', 'datasets/sickEuthyroid_test.csv', 'datasets/sickEuthyroid_labels.csv'], ['datasets/abalone7_train.csv', 'datasets/abalone7_test.csv', 'datasets/abalone7_labels.csv'], ['datasets/satellite_train.csv', 'datasets/satellite_test.csv', 'datasets/satellite_labels.csv'], ['datasets/ecoli_train.csv', 'datasets/ecoli_test.csv', 'datasets/ecoli_labels.csv']], 3, 'methods/mlpack/decision_tree.py', ['csv', 'txt', 'arff'], ['metric'], 'None', ['None'])]}, 'PCA': {'{}': [('mlpack', ['datasets/iris.csv', 'datasets/wine.csv', 'datasets/cities.csv', 'datasets/diabetes_X.csv'], 3, 'methods/mlpack/pca.py', ['csv', 'txt'], ['metric'], 'None', ['None'])]}}
{'general': dict_items([('timeout', 9000), ('databaseHost', 'localhost'), ('port', 3306), ('database', 'benchmarks'), ('driver', 'mysql'), ('keepReports', 20), ('bootstrap', 10), ('libraries', ['mlpack', 'shogun', 'weka', 'scikit', 'mlpy', 'flann', 'ann', 'annoy', 'mrpt', 'dlibml']), ('version', ['HEAD', '3.2.0', '3.6.11', '0.15.1', '3.5.0', '1.8.4', '1.1.2', '1.8.3', '0.1', '19.4'])]), 'DTC': {'{}': [('mlpack', [['datasets/iris_train.csv', 'datasets/iris_test.csv', 'datasets/iris_labels.csv'], ['datasets/oilspill_train.csv', 'datasets/oilspill_test.csv', 'datasets/oilspill_labels.csv'], ['datasets/scene_train.csv', 'datasets/scene_test.csv', 'datasets/scene_labels.csv'], ['datasets/webpage_train.csv', 'datasets/webpage_test.csv', 'datasets/webpage_labels.csv'], ['datasets/isolet_train.csv', 'datasets/isolet_test.csv', 'datasets/isolet_labels.csv'], ['datasets/mammography_train.csv', 'datasets/mammography_test.csv', 'datasets/mammography_labels.csv'], ['datasets/reuters_train.csv', 'datasets/reuters_test.csv', 'datasets/reuters_labels.csv'], ['datasets/abalone19_train.csv', 'datasets/abalone19_test.csv', 'datasets/abalone19_labels.csv'], ['datasets/sickEuthyroid_train.csv', 'datasets/sickEuthyroid_test.csv', 'datasets/sickEuthyroid_labels.csv'], ['datasets/abalone7_train.csv', 'datasets/abalone7_test.csv', 'datasets/abalone7_labels.csv'], ['datasets/satellite_train.csv', 'datasets/satellite_test.csv', 'datasets/satellite_labels.csv'], ['datasets/ecoli_train.csv', 'datasets/ecoli_test.csv', 'datasets/ecoli_labels.csv']], 3, 'methods/mlpack/decision_tree.py', ['csv', 'txt', 'arff'], ['metric'], 'None', ['None'])]}, 'PCA': {'{}': [('mlpack', ['datasets/iris.csv', 'datasets/wine.csv', 'datasets/cities.csv', 'datasets/diabetes_X.csv'], 3, 'methods/mlpack/pca.py', ['csv', 'txt'], ['metric'], 'None', ['None'])]}, 'PERCEPTRON': {'{"max_iterations": 10000}': [('mlpack', [['datasets/iris_train.csv', 'datasets/iris_test.csv', 'datasets/iris_labels.csv'], ['datasets/oilspill_train.csv', 'datasets/oilspill_test.csv', 'datasets/oilspill_labels.csv'], ['datasets/scene_train.csv', 'datasets/scene_test.csv', 'datasets/scene_labels.csv'], ['datasets/webpage_train.csv', 'datasets/webpage_test.csv', 'datasets/webpage_labels.csv'], ['datasets/isolet_train.csv', 'datasets/isolet_test.csv', 'datasets/isolet_labels.csv'], ['datasets/mammography_train.csv', 'datasets/mammography_test.csv', 'datasets/mammography_labels.csv'], ['datasets/reuters_train.csv', 'datasets/reuters_test.csv', 'datasets/reuters_labels.csv'], ['datasets/abalone19_train.csv', 'datasets/abalone19_test.csv', 'datasets/abalone19_labels.csv'], ['datasets/sickEuthyroid_train.csv', 'datasets/sickEuthyroid_test.csv', 'datasets/sickEuthyroid_labels.csv'], ['datasets/abalone7_train.csv', 'datasets/abalone7_test.csv', 'datasets/abalone7_labels.csv'], ['datasets/satellite_train.csv', 'datasets/satellite_test.csv', 'datasets/satellite_labels.csv'], ['datasets/ecoli_train.csv', 'datasets/ecoli_test.csv', 'datasets/ecoli_labels.csv']], 3, 'methods/mlpack/perceptron.py', ['csv', 'txt', 'arff'], ['metric'], 'None', ['None'])]}}
.... and many more lines like this
```  

After patch output:
```
/home/uriel/Applications/miniconda3/bin/python3 benchmark/run_benchmark.py -c config.yaml -b shogun -l False -u False -m ALLKNN --f "" --n False -r "" -p ""
[WARN ] No module named simplejson
[INFO ] CPU Model:  Intel(R) Core(TM) i3-3217U CPU @ 1.80GHz
[INFO ] Distribution: debian stretch/sid
[INFO ] Platform: x86_64
[INFO ] Memory: 7.6943359375 GB
[INFO ] CPU Cores: 4
[INFO ] Method: ALLKNN
[INFO ] Options: {'k': 3}
[INFO ] Library: shogun
[INFO ] Dataset: wine
[INFO ] Dataset: cloud
[INFO ] Dataset: wine
```