### PR TITLE
Add abalone dataset

### DIFF
--- a/datasets/dataset-urls.txt
+++ b/datasets/dataset-urls.txt
@@ -2,6 +2,7 @@
 TomsHardware.csv mlpack.org/datasets/TomsHardware.tar.gz
 Twitter.csv mlpack.org/datasets/Twitter.tar.gz
 USCensus1990*.csv mlpack.org/datasets/USCensus1990.tar.gz
+abalone.csv mlpack.org/datasets/abalone.tar.gz
 abalone19*.csv mlpack.org/datasets/abalone19.tar.gz
 abalone7*.csv mlpack.org/datasets/abalone7.tar.gz
 arcene*.csv mlpack.org/datasets/arcene.tar.gz

--- a/libraries/package-urls.txt
+++ b/libraries/package-urls.txt
@@ -3,7 +3,7 @@ ann https://www.cs.umd.edu/~mount/ANN/Files/1.1.2/ann_1.1.2.tar.gz
 flann https://github.com/mariusmuja/flann/archive/1.9.1.tar.gz
 HLearn https://github.com/mikeizbicki/HLearn/archive/2.0.0.0.tar.gz
 subhask https://github.com/mikeizbicki/subhask/archive/subhask-0.1.tar.gz
-mlpack http://www.mlpack.org/files/mlpack-3.0.2.tar.gz
+mlpack http://www.mlpack.org/files/mlpack-3.0.3.tar.gz
 mlpy http://freefr.dl.sourceforge.net/project/mlpy/mlpy%203.5.0/mlpy-3.5.0.tar.gz
 scikit https://github.com/scikit-learn/scikit-learn/archive/0.18.1.tar.gz
 shogun https://github.com/shogun-toolbox/shogun/archive/shogun_6.0.0.tar.gz

--- a/methods/scikit/qda.py
+++ b/methods/scikit/qda.py
@@ -29,7 +29,7 @@ from definitions import *
 from misc import *
 
 import numpy as np
-from sklearn.qda import QDA as SQDA
+from sklearn.discriminant_analysis import QuadraticDiscriminantAnalysis as SQDA
 
 '''
 This class implements the Quadratic Discriminant Analysis benchmark.

--- a/tests/benchmark_linear_regression.py
+++ b/tests/benchmark_linear_regression.py
@@ -186,7 +186,6 @@ class LinearRegression_MLPY_TEST(unittest.TestCase):
   '''
   def test_RunMetrics(self):
     result = self.instance.RunMetrics({})
-    print(result)
     self.assertTrue(result["Runtime"] > 0)
 
 '''


### PR DESCRIPTION
Add missing abalone dataset to prevent config check failure, see http://ci.mlpack.org/view/pull%20requests/job/pull-requests%20benchmarks%20benchmark/10/console for an example.